### PR TITLE
Camera fixes and other trivial oddities.

### DIFF
--- a/egolib/src/egolib/extensions/SDL_extensions.c
+++ b/egolib/src/egolib/extensions/SDL_extensions.c
@@ -163,7 +163,7 @@ void SDLX_output_sdl_gl_attrib( SDLX_sdl_gl_attrib_t * patt )
     fprintf( LOCAL_STDOUT, "\tSDL_GL_ACCUM_ALPHA_SIZE   == %d\n", patt->accum[3] );
     fprintf( LOCAL_STDOUT, "\tSDL_GL_STEREO             == %d\n", patt->stereo );
 
-#if !defined(__unix)
+#if !defined(__unix__)
     fprintf( LOCAL_STDOUT, "\tSDL_GL_MULTISAMPLEBUFFERS == %d\n", patt->multi_buffers );
     fprintf( LOCAL_STDOUT, "\tSDL_GL_MULTISAMPLESAMPLES == %d\n", patt->multi_samples );
     fprintf( LOCAL_STDOUT, "\tSDL_GL_ACCELERATED_VISUAL == %d\n", patt->accelerated_visual );

--- a/egolib/src/egolib/extensions/ogl_extensions.c
+++ b/egolib/src/egolib/extensions/ogl_extensions.c
@@ -170,8 +170,8 @@ void oglx_Get_Screen_Info( oglx_caps_t * pcaps )
     pcaps->gl_renderer    = GL_DEBUG( glGetString )( GL_RENDERER );
     pcaps->gl_extensions  = GL_DEBUG( glGetString )( GL_EXTENSIONS );
 
-    pcaps->glu_version    = GL_DEBUG( gluGetString )( GL_VERSION );
-    pcaps->glu_extensions = GL_DEBUG( gluGetString )( GL_EXTENSIONS );
+    pcaps->glu_version    = GL_DEBUG( gluGetString )( GLU_VERSION );
+    pcaps->glu_extensions = GL_DEBUG( gluGetString )( GLU_EXTENSIONS );
 
     GL_DEBUG( glGetIntegerv )( GL_MAX_MODELVIEW_STACK_DEPTH,     &pcaps->max_modelview_stack_depth );
     GL_DEBUG( glGetIntegerv )( GL_MAX_PROJECTION_STACK_DEPTH,    &pcaps->max_projection_stack_depth );

--- a/egolib/src/egolib/frustum.c
+++ b/egolib/src/egolib/frustum.c
@@ -223,6 +223,9 @@ geometry_rv egolib_frustum_intersects_bv(const egolib_frustum_t * self,const bv_
 
     finished = false;
 
+    /// @todo PF@> Something's wrong; this returns intersect/inside for tiles not actually being
+    ///            in the frustum, just force the complete calc for now.
+#if 0
     if ( !finished )
     {
         intersect_rv = point_intersects_aabb( self->origin.v, bv->data.mins, bv->data.maxs );
@@ -308,6 +311,7 @@ geometry_rv egolib_frustum_intersects_bv(const egolib_frustum_t * self,const bv_
                 break;
         }
     }
+#endif
 
     if ( !finished )
     {

--- a/egolib/src/egolib/vfs.c
+++ b/egolib/src/egolib/vfs.c
@@ -2310,12 +2310,18 @@ int vfs_add_mount_point( const char * root_path, const char * relative_path, con
 
     /// @note ZF@> 2010-06-30 vfs_convert_fname_sys() broke the Linux version
     /// @note BB@> 2010-06-30 the error in vfs_convert_fname_sys() might be fixed now
+    /// @note PF@> 2015-01-01 this should be unneeded. root_path and relative_path should both
+    ///                       sys-dependent paths, unless Windows does something strange?
+#if 0
     loc_dirname = vfs_convert_fname_sys( dirname );
+#else
+    loc_dirname = dirname;
+#endif
 
     if ( _vfs_mount_info_add( mount_point, root_path, relative_path ) )
     {
         retval = PHYSFS_mount( loc_dirname, mount_point, append );
-        if ( 1 != retval )
+        if ( 0 == retval )
         {
             // go back and remove the mount info, since PHYSFS rejected the
             // data we gave it

--- a/game/src/game/camera.h
+++ b/game/src/game/camera.h
@@ -159,6 +159,7 @@ struct camera_t
 
     // effects
     float         motion_blur;         ///< Blurry effect
+    float         motion_blur_old;     ///< Blurry effect one frame ago (used to init the accum buffer)
     int           swing;               ///< Camera swingin'
     int           swing_rate;
     float         swing_amp;

--- a/game/src/game/game.c
+++ b/game/src/game/game.c
@@ -5426,6 +5426,7 @@ egolib_rv game_copy_imports( import_list_t * imp_lst )
 
     // delete the data in the directory
     vfs_removeDirectoryAndContents( "import", VFS_TRUE );
+    vfs_remove_mount_point("import");
 
     // make sure the directory exists
     if ( !vfs_mkdir( "/import" ) )
@@ -5433,6 +5434,7 @@ egolib_rv game_copy_imports( import_list_t * imp_lst )
         log_warning( "mnu_copy_local_imports() - Could not create the import folder. (%s)\n", vfs_getError() );
         return rv_error;
     }
+    vfs_add_mount_point( fs_getUserDirectory(), "import", "mp_import", 1 );
 
     // copy all of the imports over
     for ( import_idx = 0; import_idx < imp_lst->count; import_idx++ )

--- a/game/src/game/graphic.c
+++ b/game/src/game/graphic.c
@@ -1755,6 +1755,11 @@ void gfx_system_init_SDL_graphics()
     sdl_vparam.gl_att.multi_buffers      = ( cfg.multisamples > 1 ) ? 1 : 0;
     sdl_vparam.gl_att.multi_samples      = cfg.multisamples;
     sdl_vparam.gl_att.accelerated_visual = GL_TRUE;
+    
+    sdl_vparam.gl_att.accum[0]           = 8;
+    sdl_vparam.gl_att.accum[1]           = 8;
+    sdl_vparam.gl_att.accum[2]           = 8;
+    sdl_vparam.gl_att.accum[3]           = 8;
 
     ogl_vparam.dither         = cfg.use_dither ? GL_TRUE : GL_FALSE;
     ogl_vparam.antialiasing   = GL_TRUE;
@@ -1809,9 +1814,14 @@ void gfx_system_render_world( const camera_t * pcam, const int render_list_index
 
         if ( pcam->motion_blur > 0 )
         {
+            if (pcam->motion_blur_old < 0.001f)
+                GL_DEBUG(glAccum)(GL_LOAD, 1);
             //Do motion blur
-            GL_DEBUG( glAccum )( GL_MULT, pcam->motion_blur );
-            GL_DEBUG( glAccum )( GL_ACCUM, 1.0f - pcam->motion_blur );
+            if (!GProc->mod_paused)
+            {
+                GL_DEBUG( glAccum )( GL_MULT, pcam->motion_blur );
+                GL_DEBUG( glAccum )( GL_ACCUM, 1.0f - pcam->motion_blur );
+            }
             GL_DEBUG( glAccum )( GL_RETURN, 1.0f );
         }
     }
@@ -6426,7 +6436,7 @@ gfx_rv gfx_make_renderlist( renderlist_t * prlist, const camera_t * pcam )
 
     // get the tiles in the center of the view
     _renderlist_colst.top = 0;
-    mesh_BSP_collide_frustum(getMeshBSP(), &( pcam->frustum_big ), NULL, &_renderlist_colst );
+    mesh_BSP_collide_frustum(getMeshBSP(), &( pcam->frustum ), NULL, &_renderlist_colst );
 
     // transfer valid _renderlist_colst entries to the dolist
     if ( gfx_error == renderlist_add_colst( prlist, &_renderlist_colst ) )

--- a/game/src/game/script_functions.c
+++ b/game/src/game/script_functions.c
@@ -3009,6 +3009,7 @@ Uint8 scr_RestockTargetAmmoIDFirst( script_state_t * pstate, ai_state_t * pself 
     /// if the item matches the ID given ( parent or child type )
 
     int     iTmp;
+    int     ichr;
     chr_t * pself_target;
 
     SCRIPT_FUNCTION_BEGIN();
@@ -3016,13 +3017,25 @@ Uint8 scr_RestockTargetAmmoIDFirst( script_state_t * pstate, ai_state_t * pself 
     SCRIPT_REQUIRE_TARGET( pself_target );
 
     iTmp = 0;  // Amount of ammo given
-
-    PACK_BEGIN_LOOP( pself_target->inventory, pitem, item )
+    
+    ichr = pself_target->holdingwhich[SLOT_LEFT];
+    iTmp += restock_ammo(ichr, pstate->argument);
+    
+    if (iTmp == 0)
     {
-        iTmp += restock_ammo( item, pstate->argument );
-        if ( 0 != iTmp ) break;
+        ichr = pself_target->holdingwhich[SLOT_RIGHT];
+        iTmp += restock_ammo(ichr, pstate->argument);
     }
-    PACK_END_LOOP()
+
+    if (iTmp == 0)
+    {
+        PACK_BEGIN_LOOP( pself_target->inventory, pitem, item )
+        {
+            iTmp += restock_ammo( item, pstate->argument );
+            if ( 0 != iTmp ) break;
+        }
+        PACK_END_LOOP()
+    }
 
     pstate->argument = iTmp;
     returncode = ( iTmp != 0 );


### PR DESCRIPTION
Should fix #2, but minor clip errors occur when rotating or zooming the camera.
Grog and daze now properly use the accumulative buffer.
Camera rolling partially fixed.
Also fixes White Beard's gonne reloading.