### PR TITLE
Camera segfault fix

### DIFF
--- a/cartman/src/cartman/cartman.c
+++ b/cartman/src/cartman/cartman.c
@@ -2235,9 +2235,7 @@ int main( int argcnt, char* argtext[] )
     setup_init_base_vfs_paths();
 
     // register the logging code
-    log_init( vfs_resolveWriteFilename( "/debug/log.txt" ) );
-    log_setLoggingLevel( 2 );
-    atexit( log_shutdown );
+    log_init(vfs_resolveWriteFilename( "/debug/log.txt" ), LOG_INFO);
 
     if ( !setup_read_vfs() )
     {

--- a/egolib/Makefile.Windows
+++ b/egolib/Makefile.Windows
@@ -10,8 +10,10 @@ SOURCES += $(wildcard ./src/egolib/*.cpp) $(wildcard ./src/egolib/file_formats/*
 SOURCES     += ./src/egolib/platform/sys_win32.c
 SOURCES     += ./src/egolib/platform/file_win.c
 
-SOURCES := $(filter-out ./src/egolib/bsp_aabb.c, $(SOURCES))
+#Exclude these files
 SOURCES := $(filter-out ./src/egolib/bsp_leaf.c, $(SOURCES))
+SOURCES := $(filter-out ./src/egolib/platform/sys_linux.c, $(SOURCES))
+SOURCES := $(filter-out ./src/egolib/platform/file_linux.c, $(SOURCES))
 
 
 #-------------------

--- a/egolib/src/egolib/egolib_config.h
+++ b/egolib/src/egolib/egolib_config.h
@@ -28,8 +28,6 @@
 
 #undef  USE_LUA_CONSOLE       ///< LUA support for the console
 
-#define LOG_TO_CONSOLE        ///< dump all log info to file and to the console. Only useful if your compiler generates console for program output. Otherwise the results will end up in a file called stdout.txt
-
 /// How much script debugging.
 ///    0 -- debugging off ( requires defined(_DEBUG) )
 /// >= 1 -- Log the amount of script time that every object uses (requires defined(_DEBUG) and DEBUG_PROFILE)

--- a/egolib/src/egolib/log.h
+++ b/egolib/src/egolib/log.h
@@ -28,16 +28,24 @@ extern "C"
 {
 #endif
 
+enum LogLevel : uint8_t
+{
+    LOG_NONE,       ///< No log level, always printed directly to output
+    LOG_ERROR,      ///< Fatal unrecoverable error (also terminates program)
+    LOG_WARNING,    ///< Warning, something went wrong but nothing critical
+    LOG_INFO,       ///< Information logging, default level
+    LOG_DEBUG       ///< Verbose debug logging, useful for developers and debugging
+};
+
 //--------------------------------------------------------------------------------------------
 // FUNCTION PROTOTYPES
 //--------------------------------------------------------------------------------------------
 
-    void   log_init( const char * logname );
+    void   log_init(const char * logname, LogLevel logLevel);
     void   log_shutdown( void );
 
     FILE * log_get_file( void );
 
-    void   log_setLoggingLevel( int level );
     void   log_message( const char *format, ... ) GCC_PRINTF_FUNC( 1 );
     void   log_debug( const char *format, ... ) GCC_PRINTF_FUNC( 1 );
     void   log_info( const char *format, ... ) GCC_PRINTF_FUNC( 1 );

--- a/egolib/src/egolib/platform.h
+++ b/egolib/src/egolib/platform.h
@@ -147,8 +147,8 @@ extern "C"
 //--------------------------------------------------------------------------------------------
 // windows definitions
 
-#if defined(WIN32) || defined(_WIN32) || defined (__WIN32) || defined(__WIN32__)
-
+#if defined(WIN32) || defined(_WIN32) || defined (__WIN32) || defined(__WIN32__) || defined(__WIN64__) || defined(WIN64) || defined(_WIN64) || defined(__WIN64)
+#define __WINDOWS__
 // map all of these possibilities to WIN32
 #    if !defined(WIN32)
 #        define WIN32
@@ -186,22 +186,6 @@ extern "C"
 
 #endif
 
-//--------------------------------------------------------------------------------------------
-//--------------------------------------------------------------------------------------------
-//amiga definitions
-#if defined(__amigaos4__)
-
-/// amigaos uses __unix__
-#    if !defined(__unix__)
-#        define __unix__
-#    endif
-
-#    include <unistd.h>
-
-/// make this function work cross-platform
-#    define stricmp  strcasecmp
-
-#endif
 //--------------------------------------------------------------------------------------------
 //--------------------------------------------------------------------------------------------
 

--- a/game/Makefile.Windows
+++ b/game/Makefile.Windows
@@ -34,7 +34,7 @@ SDLCONF_C := $(shell sdl-config --cflags)
 # the compiler options
 
 CXX      := g++
-CXXFLAGS  := $(INCLUDES) $(SDLCONF_C) -std=c++11 -O0 -D_CONSOLE
+CXXFLAGS  := $(INCLUDES) $(SDLCONF_C) -std=c++11 -O0 -D_DEBUG 
 #-Wall -Weffc++
 
 #debug options
@@ -42,12 +42,13 @@ CXXFLAGS += -ggdb -fdiagnostics-color=always
 #CXXFLAGS += -fsanitize=undefined -fsanitize=leak -fsanitize=address
 #CXXFLAGS += -fsanitize=integer-divide-by-zero -fsanitize=null -fsanitize=vla-bound -fsanitize=return -fsanitize=signed-integer-overflow -fsanitize=enum
 
-LINKER_LIBS := -lmingw32 -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -static-libgcc -lSHFolder -lAdvapi32
+LINKER_LIBS := -lmingw32 -mconsole -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -static-libgcc -lSHFolder -lAdvapi32
 LINKER_LIBS += -L../egolib/ -legoboo
 LINKER_LIBS += -L/usr/local/lib -lSDLmain -lSDL -lSDL_mixer -lSDL_ttf -lSDL_image
 LINKER_LIBS += -lphysfs
 LINKER_LIBS += -lenet -lwsock32 -lws2_32
-LINKER_LIBS += -lopengl32 -lglu32 -lShlwapi -lwinmm
+LINKER_LIBS += -lopengl32 -lglu32 -lShlwapi -lwinmm 
+#-static
 
 
 #------------------------------------

--- a/game/src/game/egoboo.c
+++ b/game/src/game/egoboo.c
@@ -100,8 +100,7 @@ int do_ego_proc_begin( ego_process_t * eproc )
     setup_init_base_vfs_paths();
 
     // Initialize logging next, so that we can use it everywhere.
-    log_init(vfs_resolveWriteFilename( "/debug/log.txt" ) );
-    log_setLoggingLevel( 3 );
+    log_init(vfs_resolveWriteFilename("/debug/log.txt"), LOG_DEBUG);
 
     // start initializing the various subsystems
     log_message( "Starting Egoboo " VERSION " ...\n"  );

--- a/game/src/game/graphics/Camera.hpp
+++ b/game/src/game/graphics/Camera.hpp
@@ -156,6 +156,11 @@ public:
      */
     void resetTarget( const ego_mesh_t * pmesh);
 
+    /**
+    * @brief Changes the camera mode
+    **/
+    void setCameraMode(CameraMode mode) {_moveMode = mode;}
+
 protected:
     /**
     * @brief This function makes the camera turn to face the character

--- a/game/src/game/graphics/CameraSystem.cpp
+++ b/game/src/game/graphics/CameraSystem.cpp
@@ -31,9 +31,14 @@ void CameraSystem::begin(const size_t numberOfCameras)
     	return;
     }
 
-    //Create cameras (allow for 0 cameras)
-    for(size_t i = 0; i < std::min(numberOfCameras, MAX_CAMERAS); ++i) {
+    //Create cameras
+    for(size_t i = 0; i < CLIP<size_t>(numberOfCameras, 1, MAX_CAMERAS); ++i) {
     	_cameraList.push_back( std::make_shared<Camera>(_cameraOptions) );
+    }
+
+    //If there are no valid players then make free movement camera
+    if(numberOfCameras == 0) {
+        _cameraList[0].setCameraMode(CAM_FREE);
     }
 
     // we're initialized.

--- a/game/src/game/graphics/CameraSystem.cpp
+++ b/game/src/game/graphics/CameraSystem.cpp
@@ -38,7 +38,7 @@ void CameraSystem::begin(const size_t numberOfCameras)
 
     //If there are no valid players then make free movement camera
     if(numberOfCameras == 0) {
-        _cameraList[0].setCameraMode(CAM_FREE);
+        _cameraList[0]->setCameraMode(CAM_FREE);
     }
 
     // we're initialized.


### PR DESCRIPTION
Fixes segfault when a module starts without any local players. CAM_FREE mode is used instead where camera is controlled free-form mode using the keypad. There seems to be an issue however where the keypad buttons are not detected but at least it no longer crashes.