### PR TITLE
TrueType font rewrite

### DIFF
--- a/egolib/src/egolib/Graphics/Font.cpp
+++ b/egolib/src/egolib/Graphics/Font.cpp
@@ -29,207 +29,803 @@
 #include "egolib/Renderer/Renderer.hpp"
 #include "egolib/log.h"
 #include "egolib/vfs.h"
+#include "egolib/Core/EnvironmentError.hpp"
 
 // this include must be the absolute last include
 #include "egolib/mem.h"
 
 //--------------------------------------------------------------------------------------------
 //--------------------------------------------------------------------------------------------
-
 namespace Ego
 {
-    struct Font::StringCacheData : Id::NonCopyable
-    {
-        Uint32 lastUseInTicks;
-        oglx_texture_t *tex;
-        std::string text;
-        
-        StringCacheData() :
-            lastUseInTicks(0),
-            tex(new oglx_texture_t())
-        {
-            if (!tex)
-            {
-                throw std::runtime_error("unable to create texture");
-            }
-        }
-        
-        ~StringCacheData()
-        {
-            if (tex != nullptr)
-            {
-                delete tex;
-                tex = nullptr;
-            }
-        }
-    };
+struct Font::RenderedTextCache : Id::NonCopyable
+{
+    std::shared_ptr<Font::LaidTextRenderer> cache;
+    uint32_t lastUseInTicks;
+    std::string text;
+    int width;
+    int height;
+    int spacing;
     
-    Font::Font(const std::string &fileName, int pointSize) :
-    _ttfFont(nullptr),
-    _stringCache(),
-    _sortedCache()
+    bool isEquivalent(const std::string &t, int w, int h, int s)
     {
-        SDL_RWops *rwops = vfs_openRWopsRead(fileName.c_str());
-        if (rwops == nullptr)
-        {
-            log_warning("Failed to open '%s' via vfs: %s\n", fileName.c_str(), vfs_getError());
-            return;
-        }
-        _ttfFont = TTF_OpenFontRW(rwops, 1, pointSize);
-        if (_ttfFont == nullptr)
-        {
-            log_warning("Failed to open '%s' via SDL_ttf: %s\n", fileName.c_str(), TTF_GetError());
-            return;
-        }
+        return w == width && h == height && s == spacing && t == text;
     }
     
-    Font::~Font()
-    {
-        if (_ttfFont && Ego::FontManager::isInitialized()) TTF_CloseFont(_ttfFont);
-    }
-    
-    void Font::getTextSize(const std::string &text, int *width, int *height) const
-    {
-        if (_ttfFont == nullptr) return;        
-        TTF_SizeUTF8(_ttfFont, text.c_str(), width, height);
-    }
-    
-    void Font::getTextBoxSize(const std::string &text, int spacing, int *width, int *height) const
-    {
-        if (_ttfFont == nullptr) return;
-        
-        int w = 0;
-        int h = 0;
-        if (width == nullptr) width = &w;
-        if (height == nullptr) height = &h;
-        
-        *width = 0; *height = 0;
-        for (const std::string &line : Ego::split(text, std::string("\n")))
-        {
-            if (line == "\n") continue;
-            int lineWidth = 0;
-            int lineHeight = 0;
-            TTF_SizeUTF8(_ttfFont, line.c_str(), &lineWidth, &lineHeight);
-            *width = std::max(*width, lineWidth);
-            *height += spacing;
-        }
-    }
-    
-    void Font::drawTextToTexture(oglx_texture_t *tex, const std::string &text, const Ego::Math::Colour3f &colour) const
-    {
-        if (!tex)
-        {
-            throw std::invalid_argument("nullptr == tex");
-        }
-        if (!_ttfFont)
-        {
-            throw std::logic_error("TTF font not created");
-        }
-        SDL_Color sdlColor;
-        sdlColor.r = static_cast<Uint8>(colour.getRed() * 255);
-        sdlColor.g = static_cast<Uint8>(colour.getGreen() * 255);
-        sdlColor.b = static_cast<Uint8>(colour.getBlue() * 255);
-        sdlColor.a = 255;
-        
-        SDL_Surface *textSurface = TTF_RenderUTF8_Blended(_ttfFont, text.c_str(), sdlColor);
-        if (!textSurface)
-        {
-            log_warning("Got a null surface from SDL_TTF: %s", TTF_GetError());
-            return;
-        }
-        std::shared_ptr<SDL_Surface> surface = std::shared_ptr<SDL_Surface>(textSurface, [ ](SDL_Surface *surface) { SDL_FreeSurface(surface); });
-        std::string name = "Font text '" + text + "'";
-        tex->load(name, surface);
-        tex->setAddressModeS(Ego::TextureAddressMode::Clamp);
-        tex->setAddressModeT(Ego::TextureAddressMode::Clamp);
-    }
-    
-    void Font::drawText(const std::string &text, int x, int y, const Ego::Math::Colour4f &colour)
-    {
-        if (_ttfFont == nullptr || text.empty()) return;
-        StringCacheDataPtr cache;
-        bool updateTexture = true;
-        auto cacheIterator = _stringCache.find(text);
-        if (cacheIterator != _stringCache.end() && !cacheIterator->second.expired())
-        {
-            cache = cacheIterator->second.lock();
-            updateTexture = false;
-        }
-        else if (_sortedCache.size() < 20)
-        {
-            cache = std::make_shared<StringCacheData>();
-            _sortedCache.push_back(cache);
-        }
-        else
-        {
-            std::sort(_sortedCache.begin(), _sortedCache.end(), compareStringCacheData);
-            cache = _sortedCache.at(0);
-            _stringCache.erase(cache->text);
-        }
-        
-        if (updateTexture)
-        {
-            drawTextToTexture(cache->tex, text);
-        }
-
-        float w = cache->tex->getSourceWidth();
-        float h = cache->tex->getSourceHeight();
-        float u = w / cache->tex->getWidth();
-        float v = h / cache->tex->getHeight();
-        
-        auto& renderer = Ego::Renderer::get();
-        renderer.setColour(colour);
-        renderer.setBlendingEnabled(true);
-        oglx_texture_t::bind(cache->tex);
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        GL_DEBUG(glBegin)(GL_QUADS);
-        {
-            GL_DEBUG(glTexCoord2f)(0, 0);
-            GL_DEBUG(glVertex2f)(x, y);
-            
-            GL_DEBUG(glTexCoord2f)(u, 0);
-            GL_DEBUG(glVertex2f)(x + w, y);
-            
-            GL_DEBUG(glTexCoord2f)(u, v);
-            GL_DEBUG(glVertex2f)(x + w, y + h);
-            
-            GL_DEBUG(glTexCoord2f)(0, v);
-            GL_DEBUG(glVertex2f)(x, y + h);
-        }
-        GL_DEBUG_END();
-        
-        cache->lastUseInTicks = SDL_GetTicks();
-        cache->text = text;
-        _stringCache[text] = cache;
-    }
-    
-    void Font::drawTextBox(const std::string &text, int x, int y, int width, int height, int spacing, const Ego::Math::Colour4f &colour)
-    {
-        if (_ttfFont == nullptr) return;
-        for (const std::string &line : Ego::split(text, std::string("\n")))
-        {
-            if (line == "\n") continue;
-            drawText(line, x, y, colour);
-            y += spacing;
-        }
-    }
-    
-    int Font::getLineSpacing() const
-    {
-        if (_ttfFont == nullptr) return 0;
-        return TTF_FontLineSkip(_ttfFont);
-    }
-    
-    bool Font::compareStringCacheData(const StringCacheDataPtr &a, const StringCacheDataPtr &b)
-    {
-        if (b == nullptr) return false;
-        if (a == nullptr) return true;
+    static bool isLessThan(const std::shared_ptr<RenderedTextCache> &a, const std::shared_ptr<RenderedTextCache> &b) {
         return a->lastUseInTicks < b->lastUseInTicks;
     }
+};
 
-    int Font::getFontHeight() const
+struct Font::SizedTextCache : Id::NonCopyable
+{
+    uint32_t lastUseInTicks;
+    std::string text;
+    int width;
+    int height;
+    int spacing;
+    
+    bool isEquivalent(const std::string &t, int s)
     {
-        return TTF_FontHeight(_ttfFont);
+        return s == spacing && t == text;
     }
+    
+    static bool isLessThan(const std::shared_ptr<SizedTextCache> &a, const std::shared_ptr<SizedTextCache> &b) {
+        return a->lastUseInTicks < b->lastUseInTicks;
+    }
+};
+
+struct Font::FontAtlas {
+    std::shared_ptr<oglx_texture_t> texture;
+    std::unordered_map<uint16_t, SDL_Rect> glyphs;
+};
+
+struct Font::LaidOutText {
+    std::vector<uint16_t> codepoints;
+    std::vector<SDL_Rect> positions;
+    const FontAtlas &atlas;
+    
+    LaidOutText(const FontAtlas &a) :
+        atlas(a)
+    {}
+};
+
+struct Font::LayoutOptions {
+    int maxWidth = 0;  ///< The maximum width in pixels of the constraining box; set to 0 for no constraint.
+    int maxHeight = 0; ///< The maximum height in pixels of the constraining box; set to 0 for no constraint.
+    int spacing = 0; ///< The space in pixels added between lines; if 0, it's set to @c Font::getFontSpacing()
+    bool interpretNewlines = true; ///< If @c false, newline characters do not create a new line.
+    int *textWidth = nullptr; ///< Set to the laid text's width
+    int *textHeight = nullptr; ///< Set to the laid text's height
+};
+
+Font::LaidTextRenderer::LaidTextRenderer(const std::shared_ptr<oglx_texture_t> &atlas,
+                             std::unique_ptr<VertexBuffer> &vertexBuffer) :
+_atlas(atlas),
+_vertexBuffer(std::move(vertexBuffer))
+{}
+
+void Font::LaidTextRenderer::render(int x, int y, const Ego::Math::Colour4f &colour) {
+    auto &renderer = Ego::Renderer::get();
+    struct MatrixStack {
+        MatrixStack() { GL_DEBUG(glPushMatrix)(); }
+        ~MatrixStack() { GL_DEBUG(glPopMatrix)(); }
+    } stack;
+    
+    fvec3_t pos(x, y, 0);
+    fmat_4x4_t transMat = fmat_4x4_t::translation(pos);
+    
+    renderer.multiplyMatrix(transMat);
+    renderer.setColour(colour);
+    oglx_texture_t::bind(_atlas.get());
+    renderer.render(*(_vertexBuffer.get()), Ego::PrimitiveType::Quadriliterals, 0, _vertexBuffer->getNumberOfVertices());
+}
+
+Font::Font(const std::string &fileName, int pointSize) :
+_ttfFont(),
+_renderedCache(),
+_sizedCache()
+{
+    _ttfFont = TTF_OpenFontRW(vfs_openRWopsRead(fileName), 1, pointSize);
+    
+    if (_ttfFont == nullptr) {
+        throw Ego::Core::EnvironmentError(__FILE__, __LINE__, "SDL_ttf", TTF_GetError());
+    }
+    
+    // Create an texture atlas for ASCII characters
+    std::vector<uint16_t> ascii;
+    for (int i = 0x20; i < 0x7F; i++)
+        ascii.push_back(i);
+    _atlases.push_back(createFontAtlas(ascii));
+}
+
+Font::~Font()
+{
+    if (Ego::FontManager::isInitialized()) TTF_CloseFont(_ttfFont);
+}
+
+void Font::getTextSize(const std::string &text, int *width, int *height)
+{
+    bool updateCache = true;
+    std::shared_ptr<SizedTextCache> cache = findInSizedCache(text, 0, &updateCache);
+    
+    if (updateCache)
+    {
+        int ourWidth = 0;
+        int ourHeight = 0;
+        
+        LayoutOptions options;
+        options.textWidth = &ourWidth;
+        options.textHeight = &ourHeight;
+        options.interpretNewlines = false;
+        
+        layout(text, options);
+        
+        cache->text = text;
+        cache->width = ourWidth;
+        cache->height = ourHeight;
+        cache->spacing = 0;
+    }
+    
+    if (width) *width = cache->width;
+    if (height) *height = cache->height;
+    
+    cache->lastUseInTicks = SDL_GetTicks();
+}
+
+void Font::getTextBoxSize(const std::string &text, int spacing, int *width, int *height)
+{
+    bool updateCache = true;
+    auto cache = findInSizedCache(text, spacing, &updateCache);
+    
+    if (updateCache)
+    {
+        int ourWidth = 0;
+        int ourHeight = 0;
+        
+        LayoutOptions options;
+        options.textWidth = &ourWidth;
+        options.textHeight = &ourHeight;
+        
+        layout(text, options);
+        
+        cache->text = text;
+        cache->width = ourWidth;
+        cache->height = ourHeight;
+        cache->spacing = spacing;
+    }
+    
+    if (width) *width = cache->width;
+    if (height) *height = cache->height;
+    
+    cache->lastUseInTicks = SDL_GetTicks();
+}
+
+void Font::drawTextToTexture(oglx_texture_t *tex, const std::string &text, const Ego::Math::Colour3f &colour)
+{
+    LayoutOptions options;
+    
+    std::shared_ptr<SDL_Surface> surface = layoutToTexture(text, options, colour);
+    
+    std::string name = "Font text '" + text + "'";
+    tex->load(name, surface);
+    tex->setAddressModeS(Ego::TextureAddressMode::Clamp);
+    tex->setAddressModeT(Ego::TextureAddressMode::Clamp);
+}
+
+void Font::drawTextBoxToTexture(oglx_texture_t *tex, const std::string &text, int width, int height, int spacing,
+                                const Ego::Math::Colour3f &colour)
+{
+    LayoutOptions options;
+    options.maxWidth = width;
+    options.maxHeight = height;
+    options.spacing = spacing;
+    
+    std::shared_ptr<SDL_Surface> surface = layoutToTexture(text, options, colour);
+    
+    std::string name = "Font textbox '" + text + "'";
+    tex->load(name, surface);
+    tex->setAddressModeS(Ego::TextureAddressMode::Clamp);
+    tex->setAddressModeT(Ego::TextureAddressMode::Clamp);
+}
+
+void Font::drawText(const std::string &text, int x, int y, const Ego::Math::Colour4f &colour)
+{
+    if (text.empty()) return;
+    
+    bool updateCache = true;
+    auto cache = findInRenderedCache(text, 0, 0, 0, &updateCache);
+    
+    if (updateCache)
+    {
+        cache->cache = layoutText(text, nullptr, nullptr);
+        cache->text = text;
+        cache->width = 0;
+        cache->height = 0;
+        cache->spacing = 0;
+    }
+
+    cache->cache->render(x, y, colour);
+    
+    cache->lastUseInTicks = SDL_GetTicks();
+}
+
+void Font::drawTextBox(const std::string &text, int x, int y, int width, int height, int spacing, const Ego::Math::Colour4f &colour)
+{
+    if (text.empty()) return;
+    
+    bool updateCache = true;
+    auto cache = findInRenderedCache(text, width, height, spacing, &updateCache);
+    
+    if (updateCache)
+    {
+        cache->cache = layoutTextBox(text, width, height, spacing, nullptr, nullptr);
+        cache->text = text;
+        cache->width = width;
+        cache->height = height;
+        cache->spacing = spacing;
+    }
+    
+    cache->cache->render(x, y, colour);
+    
+    cache->lastUseInTicks = SDL_GetTicks();
+}
+
+std::shared_ptr<Font::LaidTextRenderer> Font::layoutText(const std::string &text, int *textWidth, int *textHeight) {
+    LayoutOptions options;
+    options.textWidth = textWidth;
+    options.textHeight = textHeight;
+    options.interpretNewlines = false;
+    
+    return layoutToBuffer(text, options);
+}
+
+std::shared_ptr<Font::LaidTextRenderer> Font::layoutTextBox(const std::string &text, int width, int height, int spacing,
+                                                  int *textWidth, int *textHeight)
+{
+    LayoutOptions options;
+    options.textWidth = textWidth;
+    options.textHeight = textHeight;
+    options.maxWidth = width;
+    options.maxHeight = height;
+    options.spacing = spacing;
+    
+    return layoutToBuffer(text, options);
+}
+
+int Font::getLineSpacing() const
+{
+    return TTF_FontLineSkip(_ttfFont);
+}
+
+int Font::getFontHeight() const
+{
+    return TTF_FontHeight(_ttfFont);
+}
+
+void Font::layoutLine(const std::vector<uint16_t> &codepoints, size_t pos, int maxWidth, bool useNewlines,
+                      const FontAtlas &atlas, size_t *endPos, std::vector<uint16_t> &usedChars,
+                      std::vector<SDL_Rect> &positions, int *lineWidth, int *lineHeight)
+{
+    bool useWidth = maxWidth > 0;
+    uint16_t lastCodepoint = 0;
+    size_t lastWordStartPosInChars = pos;
+    size_t lastWordStartPosInUsedChars = 0;
+    int x = 0;
+    size_t currentPos;
+    bool lineCut = false;
+    
+    int maxLineWidth = 0;
+    int maxLineHeight = 0;
+    for (currentPos = pos; currentPos < codepoints.size(); currentPos++) {
+        uint16_t codepoint = codepoints[currentPos];
+        if (codepoint != '\n' && !TTF_GlyphIsProvided(_ttfFont, codepoint))
+            continue;
+        SDL_Rect rect = {0, 0, 0, 0};
+        if (codepoint != '\n') {
+            auto glyph = atlas.glyphs.find(codepoint);
+            SDL_assert(glyph != atlas.glyphs.end());
+            rect = glyph->second;
+        }
+        if (codepoint == ' ') {
+            lastWordStartPosInChars = currentPos + 1;
+            lastWordStartPosInUsedChars = usedChars.size() + 1;
+        }
+        
+        if ((useNewlines && codepoint == '\n') || (useWidth && maxWidth - x < rect.w)) {
+            if (codepoint != '\n' && codepoint != ' ' && lastWordStartPosInUsedChars > 0) {
+                currentPos = lastWordStartPosInChars;
+                auto wordStart = usedChars.begin();
+                std::advance(wordStart, lastWordStartPosInUsedChars);
+                usedChars.erase(wordStart, usedChars.end());
+                auto wordPosStart = positions.begin();
+                std::advance(wordPosStart, lastWordStartPosInUsedChars);
+                positions.erase(wordPosStart, positions.end());
+                
+                maxLineWidth = 0;
+                maxLineHeight = 0;
+                for (size_t i = 0; i < usedChars.size(); i++) {
+                    uint16_t ch = usedChars[i];
+                    auto glyph = atlas.glyphs.find(ch);
+                    SDL_Rect pos = positions[i];
+                    SDL_Rect r = glyph->second;
+                    if (maxLineHeight < r.h)
+                        maxLineHeight = r.h;
+                    if (maxLineWidth < pos.x + r.w)
+                        maxLineWidth = pos.x + r.w;
+                }
+            } else if (useNewlines && codepoint == '\n') {
+                currentPos++;
+            }
+            lineCut = true;
+            break;
+        }
+        if (codepoint == '\n')
+            continue;
+        
+        if (maxLineWidth < x+rect.w)
+            maxLineWidth = x + rect.w;
+        if (maxLineHeight < rect.h)
+            maxLineHeight = rect.h;
+        
+        int minx, advance;
+        TTF_GlyphMetrics(_ttfFont, codepoint, &minx, nullptr, nullptr, nullptr, &advance);
+        x += getFontKerning(lastCodepoint, codepoint);
+        SDL_assert(x >= 0);
+        SDL_Rect dst = {x, 0, rect.w, rect.h};
+        if (minx < 0)
+            dst.x += minx;
+        positions.push_back(dst);
+        usedChars.push_back(codepoint);
+        x += advance;
+        lastCodepoint = codepoint;
+    }
+    *endPos = currentPos;
+    *lineWidth = maxLineWidth;
+    *lineHeight = maxLineHeight;
+}
+
+Font::LaidOutText Font::layout(const std::string &text, const LayoutOptions &options) {
+    bool useHeight = options.maxHeight > 0;
+    int spacing = options.spacing;
+    if (spacing <= 0)
+        spacing = getLineSpacing();
+    
+    std::vector<uint16_t> codepoints = splitUTF8StringToCodepoints(text);
+    
+    const FontAtlas *currentAtlas = nullptr;
+    for (const FontAtlas &atlas : _atlases) {
+        bool containsAllChars = std::all_of(codepoints.begin(), codepoints.end(), [&atlas](uint16_t pos) {
+            return pos == ' ' || pos == '\n' || atlas.glyphs.find(pos) != atlas.glyphs.end();
+        });
+        
+        if (containsAllChars) {
+            currentAtlas = &atlas;
+            break;
+        }
+    }
+    
+    if (currentAtlas == nullptr) {
+        _atlases.push_back(createFontAtlas(codepoints));
+        currentAtlas = &(_atlases.at(_atlases.size() - 1));
+    }
+    
+    LaidOutText laidText(*currentAtlas);
+    
+    int maxLineWidth = 0;
+    int y = 0;
+    int maxHeight = 0;
+    
+    for (size_t pos = 0; pos < codepoints.size(); ) {
+        std::vector<SDL_Rect> linePos;
+        std::vector<uint16_t> lineUsedChars;
+        int lineWidth;
+        int lineHeight;
+        size_t newPos = pos;
+        
+        layoutLine(codepoints, pos, options.maxWidth, options.interpretNewlines, laidText.atlas, &newPos,
+                   lineUsedChars, linePos, &lineWidth, &lineHeight);
+        
+        if (newPos == pos)
+            break;
+        
+        pos = newPos;
+        
+        if (useHeight && options.maxHeight - y < lineHeight)
+            break;
+            
+        if (maxLineWidth < lineWidth)
+            maxLineWidth = lineWidth;
+        
+        laidText.codepoints.insert(laidText.codepoints.end(), lineUsedChars.begin(), lineUsedChars.end());
+        
+        for (const SDL_Rect &rect : linePos) {
+            SDL_Rect newRect = rect;
+            newRect.y += y;
+            laidText.positions.push_back(newRect);
+        }
+        
+        int ourHeight = y + lineHeight;
+        y += spacing;
+        if (maxHeight < ourHeight)
+            maxHeight = ourHeight;
+    }
+    
+    if (options.textWidth) *(options.textWidth) = maxLineWidth;
+    if (options.textHeight) *(options.textHeight) = maxHeight;
+    
+    return laidText;
+}
+
+std::shared_ptr<Font::LaidTextRenderer> Font::layoutToBuffer(const std::string &text, const LayoutOptions &options) {
+    struct TextVertex {
+        float x;
+        float y;
+        float z;
+        float u;
+        float v;
+    };
+    
+    LaidOutText laidText = layout(text, options);
+    
+    const auto &vertexDesc = Ego::VertexFormatDescriptor::get(Ego::VertexFormat::P3FT2F);
+    std::unique_ptr<VertexBuffer> buffer(new VertexBuffer(4 * laidText.codepoints.size(), vertexDesc));
+    
+    TextVertex *vertices = reinterpret_cast<TextVertex *>(buffer->lock());
+    float texWidth = laidText.atlas.texture->getWidth();
+    float texHeight = laidText.atlas.texture->getHeight();
+    
+    for (size_t i = 0; i < laidText.codepoints.size(); i++) {
+        uint16_t chr = laidText.codepoints[i];
+        SDL_Rect charPos = laidText.positions[i];
+        SDL_Rect glyphPos = laidText.atlas.glyphs.at(chr);
+        
+        float xMin = charPos.x;
+        float xMax = charPos.x + charPos.w;
+        float yMin = charPos.y;
+        float yMax = charPos.y + charPos.h;
+        
+        float uMin = (glyphPos.x) / texWidth;
+        float uMax = (glyphPos.x + glyphPos.w) / texWidth;
+        float vMin = (glyphPos.y) / texHeight;
+        float vMax = (glyphPos.y + glyphPos.h) / texHeight;
+        
+        vertices[i * 4 + 0].x = xMin;
+        vertices[i * 4 + 0].y = yMin;
+        vertices[i * 4 + 0].z = 0;
+        vertices[i * 4 + 0].u = uMin;
+        vertices[i * 4 + 0].v = vMin;
+        
+        vertices[i * 4 + 1].x = xMax;
+        vertices[i * 4 + 1].y = yMin;
+        vertices[i * 4 + 1].z = 0;
+        vertices[i * 4 + 1].u = uMax;
+        vertices[i * 4 + 1].v = vMin;
+        
+        vertices[i * 4 + 2].x = xMax;
+        vertices[i * 4 + 2].y = yMax;
+        vertices[i * 4 + 2].z = 0;
+        vertices[i * 4 + 2].u = uMax;
+        vertices[i * 4 + 2].v = vMax;
+        
+        vertices[i * 4 + 3].x = xMin;
+        vertices[i * 4 + 3].y = yMax;
+        vertices[i * 4 + 3].z = 0;
+        vertices[i * 4 + 3].u = uMin;
+        vertices[i * 4 + 3].v = vMax;
+    }
+    buffer->unlock();
+    return std::shared_ptr<LaidTextRenderer>(new LaidTextRenderer(laidText.atlas.texture, buffer));
+}
+
+std::shared_ptr<SDL_Surface> Font::layoutToTexture(const std::string &text, const LayoutOptions &options,
+                                                   const Ego::Math::Colour3f &colour) {
+    LayoutOptions ourOptions = options;
+    int surfWidth, surfHeight;
+    ourOptions.textWidth = &surfWidth;
+    ourOptions.textHeight = &surfHeight;
+    
+    LaidOutText laidText = layout(text, ourOptions);
+    
+    if (options.textWidth) *(options.textWidth) = surfWidth;
+    if (options.textHeight) *(options.textHeight) = surfHeight;
+    
+    int bpp;
+    uint32_t rmask, gmask, bmask, amask;
+    SDL_PixelFormatEnumToMasks(SDL_PIXELFORMAT_ABGR8888, &bpp, &rmask, &gmask, &bmask, &amask);
+    
+    uint8_t colourR = static_cast<uint8_t>(colour.getRed() * 255);
+    uint8_t colourG = static_cast<uint8_t>(colour.getGreen() * 255);
+    uint8_t colourB = static_cast<uint8_t>(colour.getBlue() * 255);
+    
+    uint8_t oldR, oldG, oldB;
+    
+    SDL_Surface *surf = SDL_CreateRGBSurface(0, surfWidth, surfHeight, bpp, rmask, gmask, bmask, amask);
+    SDL_FillRect(surf, nullptr, SDL_MapRGBA(surf->format, colourR, colourG, colourB, 0));
+    SDL_SetSurfaceBlendMode(surf, SDL_BLENDMODE_NONE);
+    
+    SDL_Surface *atlasSurf = laidText.atlas.texture->_source.get();
+    SDL_GetSurfaceColorMod(atlasSurf, &oldR, &oldG, &oldB);
+    SDL_SetSurfaceColorMod(atlasSurf, colourR, colourG, colourB);
+    
+    for (size_t i = 0; i < laidText.codepoints.size(); i++) {
+        uint16_t chr = laidText.codepoints[i];
+        SDL_Rect charPos = laidText.positions[i];
+        SDL_Rect glyphPos = laidText.atlas.glyphs.at(chr);
+        SDL_BlitSurface(atlasSurf, &glyphPos, surf, &charPos);
+    }
+    
+    SDL_SetSurfaceColorMod(atlasSurf, oldR, oldG, oldB);
+    
+    return std::shared_ptr<SDL_Surface>(surf, SDL_FreeSurface);
+}
+
+Font::FontAtlas Font::createFontAtlas(const std::vector<std::string> &chars) const {
+    std::vector<uint16_t> codepoints;
+    for (const std::string & chr : chars)
+        codepoints.push_back(convertUTF8ToCodepoint(chr));
+    return createFontAtlas(codepoints);
+}
+
+Font::FontAtlas Font::createFontAtlas(const std::vector<uint16_t> &codepoints) const {
+    SDL_Color white = {255, 255, 255, 255};
+    std::vector<SDL_Surface *> images;
+    std::vector<SDL_Rect> pos;
+    
+    for (uint16_t cp : codepoints) {
+        SDL_Surface *surf = nullptr;
+        if (TTF_GlyphIsProvided(_ttfFont, cp))
+            surf = TTF_RenderGlyph_Blended(_ttfFont, cp, white);
+        images.push_back(surf);
+    }
+    
+    int currentMaxSize = 128;
+    GLint maxTextureSize = 0;
+    GL_DEBUG(glGetIntegerv)(GL_MAX_TEXTURE_SIZE, &maxTextureSize);
+    SDL_Surface *atlas = nullptr;
+    
+    int bpp;
+    uint32_t rmask, gmask, bmask, amask;
+    SDL_PixelFormatEnumToMasks(SDL_PIXELFORMAT_ABGR8888, &bpp, &rmask, &gmask, &bmask, &amask);
+    
+    while (currentMaxSize <= maxTextureSize) {
+        atlas = SDL_CreateRGBSurface(0, currentMaxSize, currentMaxSize, bpp, rmask, gmask, bmask, amask);
+        SDL_FillRect(atlas, nullptr, SDL_MapRGBA(atlas->format, 255, 255, 255, 0));
+        SDL_SetSurfaceBlendMode(atlas, SDL_BLENDMODE_NONE);
+        
+        int x = 0, y = 0;
+        int currentHeight = 0;
+        bool fits = true;
+        
+        for (SDL_Surface *surf : images) {
+            if (surf == nullptr) {
+                pos.push_back({0, 0, 0, 0});
+                continue;
+            }
+            
+            if (currentMaxSize < surf->w || currentMaxSize < surf->h) {
+                fits = false;
+                break;
+            }
+            
+            if (currentMaxSize - x < surf->w) {
+                y += currentHeight + 1;
+                x = 0;
+                currentHeight = 0;
+            }
+            
+            if (currentHeight < surf->h)
+                currentHeight = surf->h;
+            
+            if (currentMaxSize - y < currentHeight) {
+                fits = false;
+                break;
+            }
+            
+            SDL_Rect dst = {x, y, surf->w, surf->h};
+            SDL_BlitSurface(surf, nullptr, atlas, &dst);
+            pos.push_back(dst);
+            x += surf->w + 1;
+        }
+        
+        if (fits)
+            break;
+        
+        log_debug("Couldn't fit atlas into %d texture, trying %d instead\n", currentMaxSize, currentMaxSize << 1);
+        currentMaxSize <<= 1;
+        pos.clear();
+        SDL_FreeSurface(atlas);
+        atlas = nullptr;
+    }
+    
+    if (!atlas) {
+        log_error("Could not fit a font atlas into a %d by %d texture!\n", maxTextureSize, maxTextureSize);
+        SDL_assert(atlas);
+    }
+    
+    FontAtlas retval;
+    for (int i = 0; i < images.size(); i++) {
+        if (images[i] == nullptr)
+            continue;
+        retval.glyphs.insert(std::make_pair(codepoints[i], pos[i]));
+        SDL_FreeSurface(images[i]);
+    }
+    
+    std::shared_ptr<SDL_Surface> atlasPtr(atlas, SDL_FreeSurface);
+    retval.texture.reset(new oglx_texture_t());
+    retval.texture->load("font atlas", atlasPtr);
+    retval.texture->setAddressModeS(Ego::TextureAddressMode::Clamp);
+    retval.texture->setAddressModeT(Ego::TextureAddressMode::Clamp);
+    return retval;
+}
+
+std::shared_ptr<Font::RenderedTextCache> Font::findInRenderedCache(const std::string &text, int width, int height,
+                                                                   int spacing, bool *update)
+{
+    if (MAX_CACHE_SIZE == 0) {
+        *update = true;
+        return std::make_shared<RenderedTextCache>();
+    }
+    
+    if (MAX_CACHE_SIZE == 1) {
+        *update = true;
+        if (_renderedCache.empty())
+            _renderedCache.emplace_back(std::make_shared<RenderedTextCache>());
+        return _renderedCache[0];
+    }
+    
+    std::shared_ptr<Font::RenderedTextCache> cache;
+    bool updateCache = true;
+    
+    auto cacheIterator = std::find_if(_renderedCache.begin(), _renderedCache.end(),
+                                      [&](const std::shared_ptr<Font::RenderedTextCache> &ptr) {
+                                          return ptr->isEquivalent(text, width, height, spacing);
+                                      });
+    
+    if (cacheIterator != _renderedCache.end())
+    {
+        cache = *cacheIterator;
+        updateCache = false;
+    }
+    else if (_renderedCache.size() < MAX_CACHE_SIZE)
+    {
+        cache = std::make_shared<RenderedTextCache>();
+        _renderedCache.push_back(cache);
+    }
+    else
+    {
+        std::sort(_renderedCache.begin(), _renderedCache.end(), RenderedTextCache::isLessThan);
+        cache = _renderedCache.at(0);
+    }
+    
+    if (update) *update = updateCache;
+    return cache;
+}
+
+std::shared_ptr<Font::SizedTextCache> Font::findInSizedCache(const std::string &text, int spacing, bool *update) {
+    if (MAX_CACHE_SIZE == 0) {
+        *update = true;
+        return std::make_shared<SizedTextCache>();
+    }
+    
+    if (MAX_CACHE_SIZE == 1) {
+        *update = true;
+        if (_sizedCache.empty())
+            _sizedCache.emplace_back(std::make_shared<SizedTextCache>());
+        return _sizedCache[0];
+    }
+    
+    std::shared_ptr<Font::SizedTextCache> cache;
+    bool updateCache = true;
+    
+    auto cacheIterator = std::find_if(_sizedCache.begin(), _sizedCache.end(),
+                                      [&](const std::shared_ptr<Font::SizedTextCache> &ptr) {
+                                          return ptr->isEquivalent(text, spacing);
+                                      });
+    
+    if (cacheIterator != _sizedCache.end())
+    {
+        cache = *cacheIterator;
+        updateCache = false;
+    }
+    else if (_sizedCache.size() < MAX_CACHE_SIZE)
+    {
+        cache = std::make_shared<SizedTextCache>();
+        _sizedCache.push_back(cache);
+    }
+    else
+    {
+        std::sort(_sizedCache.begin(), _sizedCache.end(), SizedTextCache::isLessThan);
+        cache = _sizedCache.at(0);
+    }
+    
+    if (update) *update = updateCache;
+    return cache;
+}
+
+uint16_t Font::convertUTF8ToCodepoint(const std::string &string, size_t *pos) {
+    size_t tmpPos = 0;
+    if (pos == nullptr) pos = &tmpPos;
+    
+    uint16_t retval = 0;
+    
+    unsigned char tmp = string.at(*pos);
+    *pos += 1;
+    
+    if (tmp < 0x80) {
+        retval |= tmp;
+    } else if (tmp < 0xC2) {
+        throw std::invalid_argument("UTF-8 character invalid");
+    } else if (tmp < 0xE0) {
+        retval |= (tmp & 0x1F) << 6;
+        
+        tmp = string.at(*pos);
+        *pos += 1;
+        if ((tmp & 0xC0) != 0x80)
+            throw std::invalid_argument("UTF-8 character invalid");
+        retval |= (tmp & 0x3F);
+    } else if (tmp < 0xF0) {
+        retval |= (tmp & 0xF) << 12;
+        
+        tmp = string.at(*pos);
+        *pos += 1;
+        if ((tmp & 0xC0) != 0x80 || (retval == 0 && tmp < 0xA0))
+            throw std::invalid_argument("UTF-8 character invalid");
+        retval |= (tmp & 0x3F) << 6;
+        
+        tmp = string.at(*pos);
+        *pos += 1;
+        if ((tmp & 0xC0) != 0x80)
+            throw std::invalid_argument("UTF-8 character invalid");
+        retval |= (tmp & 0x3F);
+    } else {
+        throw std::out_of_range("UTF-8 character does not fit in a 16-bit codepoint");
+    }
+    
+    return retval;
+}
+
+std::vector<uint16_t> Font::splitUTF8StringToCodepoints(const std::string &text) {
+    std::vector<uint16_t> retval;
+    size_t pos = 0;
+    while (pos < text.size())
+        retval.push_back(convertUTF8ToCodepoint(text, &pos));
+    return retval;
+}
+
+// assume the next version of SDL_ttf is 2.0.13,
+// as of this writing (2015-07-26), the hg version where this is fixed is still 2.0.12
+#define IS_KERNING_FIXED(MAJOR, MINOR, PATCH) (SDL_VERSIONNUM(MAJOR, MINOR, PATCH) >= SDL_VERSIONNUM(2, 0, 13))
+
+#define USING_FIXED_API IS_KERNING_FIXED(SDL_TTF_MAJOR_VERSION, SDL_TTF_MINOR_VERSION, SDL_TTF_PATCHLEVEL)
+
+int Font::getFontKerning(uint16_t prevCodepoint, uint16_t nextCodepoint) const {
+    const SDL_version *ttfVer = TTF_Linked_Version();
+    bool usingFixedLibrary = IS_KERNING_FIXED(ttfVer->major, ttfVer->minor, ttfVer->patch);
+    if (usingFixedLibrary != USING_FIXED_API)
+        throw Ego::Core::EnvironmentError(__FILE__, __LINE__, "Ego::Font", "SDL_ttf compile version and linked version have different kerning APIs");
+#if USING_FIXED_API
+    // This errors-out if we're not actually compiling with the fixed API,
+    // if you get a error here, please file a bug!
+    int (*compileCheck)(TTF_Font *, uint16_t, uint16_t) = TTF_GetFontKerningSize;
+    
+    return TTF_GetFontKerningSize(_ttfFont, prevCodepoint, nextCodepoint);
+#else
+    // This errors-out if we're actually compiling with the fixed API,
+    // if you get an error here, please file a bug!
+    int (*compileCheck)(TTF_Font *, int, int) = TTF_GetFontKerningSize;
+    
+    // Abuse the fact that TTF_GlyphIsProvided just calls FT_Get_Char_Index and returns the value
+    // instead of returning if the value is not equal to 0
+    int prev_index = TTF_GlyphIsProvided(_ttfFont, prevCodepoint);
+    int next_index = TTF_GlyphIsProvided(_ttfFont, nextCodepoint);
+    
+    return TTF_GetFontKerningSize(_ttfFont, prev_index, next_index);
+#endif
+}
+    
+#undef USING_FIXED_API
+#undef IS_KERNING_FIXED
+    
 }
 

--- a/egolib/src/egolib/Graphics/Font.hpp
+++ b/egolib/src/egolib/Graphics/Font.hpp
@@ -25,140 +25,349 @@
 
 #include "egolib/typedef.h"
 #include "egolib/Math/Colour4f.hpp"
+#include "egolib/Graphics/VertexBuffer.hpp"
 
 struct oglx_texture_t;
 
 namespace Ego
 {
-    class Font final : public Id::NonCopyable
-    {
-    public:
-        Font(const std::string &fileName, int pointSize);
-        ~Font();
-        
-        /**
-         * @brief
-         *  Get the size of the given text that only has one line.
-         * @param text
-         *  the text to draw
-         * @param[out] width
-         *  the width of the text box (may be nullptr)
-         * @param[out] height
-         *  the height of the text box (may be nullptr)
-         */
-        void getTextSize(const std::string &text, int *width, int *height) const;
-        
-        /**
-         * @brief
-         *  Get the size of the given text that potentially has multiple lines.
-         * @param text
-         *  the text to draw
-         * @param spacing
-         *  the spacing (in pixels) between each line
-         * @param[out] width
-         *  the width of the text box (may be nullptr)
-         * @param[out] height
-         *  the height of the text box (may be nullptr)
-         */
-        void getTextBoxSize(const std::string &text, int spacing, int *width, int *height) const;
-        
-        
-        /**
-         * @brief
-         *  Draw text that only has one line to a texture.
-         * @param tex
-         *  the texture to draw to
-         * @param text
-         *  the text to draw
-         * @param colour
-         *  the colour of the text (default white)
-         */
-        void drawTextToTexture(oglx_texture_t *tex, const std::string &text,
-                               const Ego::Math::Colour3f &color = Ego::Math::Colour3f::white()) const;
-        
-#if 0
-        /**
-         * @brief
-         *  Draw text that potentially has multiple lines to a texture.
-         * @note this isn't implemented yet
-         * @param tex
-         *  the texture to draw to
-         * @param text
-         *  the text to draw
-         * @param width
-         *  the maximum width (NOT IMPLEMENTED)
-         * @param height
-         *  the maximum height (NOT IMPLEMENTED)
-         * @param spacing
-         *  the spacing (in pixels) between each line
-         * @param colour
-         *  the colour of the text (default white)
-         */
-        void drawTextBoxToTexture(oglx_texture_t *tex, const std::string &text, int width, int height, int spacing,
-                                  const Ego::Math::Colour3f &color = Ego::Math::Colour3f::white()) const;
-#endif
-        
-        
-        /**
-         * @brief
-         *  Draw text that only has one line to the screen.
-         * @param text
-         *  the text to draw
-         * @param x
-         *  the x position on screen
-         * @param y
-         *  the y position on screen
-         * @param colour
-         *  the colour of the text (default white)
-         */
-        void drawText(const std::string &text, int x, int y,
-                      const Ego::Math::Colour4f &colour = Ego::Math::Colour4f::white());
-        
-        /**
-         * @brief
-         *  Draw text that potentially has multiple lines to the screen.
-         * @param text
-         *  the text to draw
-         * @param x
-         *  the x position on screen
-         * @param y
-         *  the y position on screen
-         * @param width
-         *  the maximum width (NOT IMPLEMENTED)
-         * @param height
-         *  the maximum height (NOT IMPLEMENTED)
-         * @param spacing
-         *  the spacing (in pixels) between each line
-         * @param colour
-         *  the colour of the text (default white)
-         */
-        void drawTextBox(const std::string &text, int x, int y, int width, int height, int spacing,
-                         const Ego::Math::Colour4f &colour = Ego::Math::Colour4f::white());
-        
-        /** 
-         * @brief
-         *  Get the suggested line spacing for this font.
-         * @return
-         *  number of pixels suggested for line spacing
-         */
-        int getLineSpacing() const;
-        
-        /**
-        * @brief
-        *   Get the maximum pixel height of all glyphs of the loaded font. You may use this height for rendering text as close together 
-        *   vertically as possible, though adding at least one pixel height to it will space it so they can't touch.
-        * @return
-        *   The maximum pixel height of all glyphs in the font
-        **/
-        int getFontHeight() const;
+class FontManager;
 
-    private:
-        struct StringCacheData;
-        typedef std::shared_ptr<StringCacheData> StringCacheDataPtr;
-        static bool compareStringCacheData(const StringCacheDataPtr &a, const StringCacheDataPtr &b);
+/**
+ * @brief
+ *  A representation of a TrueType font.
+ */
+class Font final : public Id::NonCopyable {
+public:
+    
+    /**
+     * @brief A container and renderer for laid out text.
+     */
+    class LaidTextRenderer final : public Id::NonCopyable {
+    public:
+        /**
+         * @brief
+         *  Renders the laid out text.
+         * @param x,y
+         *  The position on screen to render the text at
+         * @param colour
+         *  The colour of the rendered text; default is white
+         */
+        void render(int x, int y, const Ego::Math::Colour4f &colour = Ego::Math::Colour4f::white());
         
-        TTF_Font *_ttfFont;
-        std::unordered_map<std::string, std::weak_ptr<StringCacheData>> _stringCache;
-        std::vector<StringCacheDataPtr> _sortedCache;
+    protected:
+        LaidTextRenderer(const std::shared_ptr<oglx_texture_t> &atlas, std::unique_ptr<VertexBuffer> &vertexBuffer);
+        friend class Font;
+    private:
+        std::shared_ptr<oglx_texture_t> _atlas;
+        std::unique_ptr<VertexBuffer> _vertexBuffer;
     };
+    
+private:
+    /// This is the maximum size for the two caches as used by
+    /// drawText and getTextSize, set this to 0 for no caching
+    CONSTEXPR static size_t MAX_CACHE_SIZE = 20;
+    
+protected:
+    Font(const std::string &fileName, int pointSize);
+    friend class FontManager;
+    
+public:
+    ~Font();
+    
+    /**
+     * @brief
+     *  Get the size of the given text that only has one line.
+     * @param text
+     *  the text to draw
+     * @param[out] width
+     *  the width of the text box (may be nullptr)
+     * @param[out] height
+     *  the height of the text box (may be nullptr)
+     */
+    void getTextSize(const std::string &text, int *width, int *height);
+    
+    /**
+     * @brief
+     *  Get the size of the given text that potentially has multiple lines.
+     * @param text
+     *  the text to draw
+     * @param spacing
+     *  the spacing (in pixels) between each line
+     * @param[out] width
+     *  the width of the text box (may be nullptr)
+     * @param[out] height
+     *  the height of the text box (may be nullptr)
+     */
+    void getTextBoxSize(const std::string &text, int spacing, int *width, int *height);
+    
+    
+    /**
+     * @brief
+     *  Draw text that only has one line to a texture.
+     * @param tex
+     *  the texture object to draw to
+     * @param text
+     *  the text to draw
+     * @param colour
+     *  the colour of the text (default white)
+     */
+    void drawTextToTexture(oglx_texture_t *tex, const std::string &text,
+                           const Ego::Math::Colour3f &color = Ego::Math::Colour3f::white());
+    
+    /**
+     * @brief
+     *  Draw text that potentially has multiple lines to a texture.
+     * @param tex
+     *  the texture object to draw to
+     * @param text
+     *  the text to draw
+     * @param width
+     *  the maximum width
+     * @param height
+     *  the maximum height
+     * @param spacing
+     *  the spacing (in pixels) between each line
+     * @param colour
+     *  the colour of the text (default white)
+     */
+    void drawTextBoxToTexture(oglx_texture_t *tex, const std::string &text, int width, int height, int spacing,
+                              const Ego::Math::Colour3f &color = Ego::Math::Colour3f::white());
+    
+    
+    /**
+     * @brief
+     *  Draw text that only has one line to the screen.
+     * @param text
+     *  the text to draw
+     * @param x
+     *  the x position on screen
+     * @param y
+     *  the y position on screen
+     * @param colour
+     *  the colour of the text (default white)
+     */
+    void drawText(const std::string &text, int x, int y,
+                  const Ego::Math::Colour4f &colour = Ego::Math::Colour4f::white());
+    
+    /**
+     * @brief
+     *  Draw text that potentially has multiple lines to the screen.
+     * @param text
+     *  the text to draw
+     * @param x
+     *  the x position on screen
+     * @param y
+     *  the y position on screen
+     * @param width
+     *  the maximum width before text wrapping (0 is no limit)
+     * @param height
+     *  the maximum height before text truncating (0 is no limit)
+     * @param spacing
+     *  the spacing (in pixels) between each line
+     * @param colour
+     *  the colour of the text (default white)
+     */
+    void drawTextBox(const std::string &text, int x, int y, int width, int height, int spacing,
+                     const Ego::Math::Colour4f &colour = Ego::Math::Colour4f::white());
+    
+    /**
+     * @brief
+     *  Create a render cache to render text that only has one line.
+     * @param text
+     *  The text to cache
+     * @param[out] textWidth,textHeight
+     *  These are set to the size of the laid text.
+     * @sa
+     *  drawText
+     */
+    std::shared_ptr<LaidTextRenderer> layoutText(const std::string &text, int *textWidth, int *textHeight);
+    
+    /**
+     * @brief
+     *  Create a render cache to render text that may have multiple lines.
+     * @param text
+     *  The text to cache
+     * @param width, height
+     *  Constraints on the laid text; use 0 for no constraint
+     * @param spacing
+     *  the spacing (in pixels) between each line
+     * @param[out] textWidth,textHeight
+     *  These are set to the size of the laid text.
+     * @sa
+     *  drawTextBox
+     */
+    std::shared_ptr<LaidTextRenderer> layoutTextBox(const std::string &text, int width, int height, int spacing,
+                                                     int *textWidth, int *textHeight);
+    
+    /** 
+     * @brief
+     *  Get the suggested line spacing for this font.
+     * @return
+     *  number of pixels suggested for line spacing
+     */
+    int getLineSpacing() const;
+    
+    /**
+    * @brief
+    *   Get the maximum pixel height of all glyphs of the loaded font. You may use this height for rendering text as close together 
+    *   vertically as possible, though adding at least one pixel height to it will space it so they can't touch.
+    * @return
+    *   The maximum pixel height of all glyphs in the font
+    **/
+    int getFontHeight() const;
+
+private:
+    /// Struct for cached text that has been rendered
+    struct RenderedTextCache;
+    /// Struct for cached text that has been sized
+    struct SizedTextCache;
+    
+    struct FontAtlas;
+    
+    /// Internal representation of laid out text.
+    struct LaidOutText;
+    
+    struct LayoutOptions;
+    
+    /**
+     * @brief
+     *  Find given values in the rendered text cache
+     * @param text,width,height,spacing
+     *  The values to look for in the cache
+     * @param update[out]
+     *  Is set to @c true when the returned cached struct needs to be updated with the given values, @c false otherwise
+     * @return
+     *  A cached struct that may need to be updated per @a update
+     */
+    std::shared_ptr<RenderedTextCache> findInRenderedCache(const std::string &text, int width, int height,
+                                                           int spacing, bool *update);
+    
+    /**
+     * @brief
+     *  Find given values in the sized text cache
+     * @param text,spacing
+     *  The values to look for in the cache
+     * @param update[out]
+     *  Is @c true when the returned cached struct needs to be updated with the given values, @c false otherwise
+     * @return
+     *  A cached struct that may need to be updated per @a update
+     */
+    std::shared_ptr<SizedTextCache> findInSizedCache(const std::string &text, int spacing, bool *update);
+    
+    /**
+     * @brief
+     *  Layout text into a LaidTextRenderer.
+     * @see layout
+     */
+    std::shared_ptr<LaidTextRenderer> layoutToBuffer(const std::string &text, const LayoutOptions &options);
+    
+    /**
+     * @brief
+     *  Layout text into a SDL_Surface.
+     * @see layout
+     */
+    std::shared_ptr<SDL_Surface> layoutToTexture(const std::string &text, const LayoutOptions &options,
+                                                 const Ego::Math::Colour3f &colour);
+    
+    /**
+     * @brief
+     *  Main function for laying out text.
+     * @param text
+     *  The text to layout
+     * @param options
+     *  The options that dictate how the text is laid out.
+     * @return
+     *  The laid out text as a group of codepoints and their positions and sizes.
+     */
+    LaidOutText layout(const std::string &text, const LayoutOptions &options);
+    
+    /**
+     * @brief
+     *  Layouts a single line
+     * @param codepoints
+     *  List of codepoints representing text
+     * @param pos
+     *  Start position in @c chars
+     * @param maxWidth
+     *  The maximum width of the line, or 0 for no limit
+     * @param useNewlines
+     *  If @c false, newlines (<tt>'\\n'</tt>) do not create a new line.
+     * @param atlas
+     *  The font atlas to use.
+     * @param[out] endPos
+     *  The character after the last character in this line
+     * @param[out] usedCodepoints
+     *  List of added codepoints
+     * @param[out] positions
+     *  List of positions of the added codepoints
+     * @param[out] lineWidth
+     *  Width of the line created
+     * @param[out] lineHeight
+     *  Height of the line created
+     */
+    void layoutLine(const std::vector<uint16_t> &codepoints, size_t pos, int maxWidth, bool useNewlines,
+                    const FontAtlas &atlas, size_t *endPos, std::vector<uint16_t> &usedCodepoints,
+                    std::vector<SDL_Rect> &positions, int *lineWidth, int *lineHeight);
+    
+    /**
+     * @brief
+     *  Creates a texture altas from the given codepoints.
+     * @param chars
+     *  The list of characters to add to the atlas
+     * @return
+     *  The created texture atlas
+     */
+    FontAtlas createFontAtlas(const std::vector<uint16_t> &codepoints) const;
+    
+    /**
+     * @brief
+     *  Creates a texture atlas from the given UTF-8 characters.
+     * @see createFontAtlas(const std::vector<uint16_t> &)
+     */
+    FontAtlas createFontAtlas(const std::vector<std::string> &chars) const;
+    
+    /**
+     * @brief
+     *  Gets the kerning between two given codepoints.
+     * @return
+     *  The kerning in pixels
+     * @note
+     *  Use this instead of @a TTF_GetFontKerningSize because SDL_ttf version 2.0.12 takes
+     *  glyph indices instead of codepoints.
+     */
+    int getFontKerning(uint16_t prevCodepoint, uint16_t nextCodepoint) const;
+    
+    /**
+     * @brief
+     *  Returns the given UTF-8 character's codepoint.
+     * @param string
+     *  The UTF-8 character
+     * @param[in,out] pos
+     *  The position in @a string to start at and will contain the position after the
+     *  character that has been converted. If @c pos is @c nullptr, it will assumed to be 0.
+     * @return
+     *  The character's codepoint as a 16-bit integer as required by SDL_ttf
+     * @throws
+     *  @c std::invalid_argument if the character is an invalid UTF-8 character
+     *  @c std::out_of_range if the character's codepoint is outside the the range of 16-bits
+     */
+    static uint16_t convertUTF8ToCodepoint(const std::string &string, size_t *pos = nullptr);
+    
+    /**
+     * @brief
+     *  Returns the codepoints of the given UTF-8 string.
+     * @param text
+     *  A UTF-8 string.
+     * @return
+     *  The list of codepoints of the given string.
+     */
+    static std::vector<uint16_t> splitUTF8StringToCodepoints(const std::string &text);
+    
+    TTF_Font *_ttfFont;
+    
+    std::vector<std::shared_ptr<RenderedTextCache>> _renderedCache;
+    std::vector<std::shared_ptr<SizedTextCache>> _sizedCache;
+    std::vector<FontAtlas> _atlases;
+};
 }

--- a/egolib/src/egolib/Graphics/FontManager.cpp
+++ b/egolib/src/egolib/Graphics/FontManager.cpp
@@ -56,6 +56,6 @@ namespace Ego
     std::shared_ptr<Font> FontManager::loadFont(const std::string &fileName, int pointSize)
     {
         if (!isInitialized()) throw std::runtime_error("font manager not initialized!");
-        return std::make_shared<Font>(fileName, pointSize);
+        return std::shared_ptr<Font>(new Font(fileName, pointSize));
     }    
 }

--- a/game/src/game/GUI/Button.cpp
+++ b/game/src/game/GUI/Button.cpp
@@ -6,6 +6,9 @@ const Ego::Math::Colour4f Button::DISABLED_BUTTON_COLOUR = {0.25f, 0.25f, 0.25f,
 
 Button::Button(int hotkey) :
     _mouseOver(false),
+    _buttonTextRenderer(),
+    _buttonTextWidth(),
+    _buttonTextHeight(),
     _buttonText(),
     _onClickFunction(nullptr),
     _hotkey(hotkey),
@@ -15,12 +18,18 @@ Button::Button(int hotkey) :
 
 Button::Button(const std::string &buttonText, int hotkey) : Button(hotkey)
 {
-    _buttonText = buttonText;
+    setText(buttonText);
 }
 
 void Button::setText(const std::string &text)
 {
     _buttonText = text;
+    if (_buttonText.empty()) {
+        _buttonTextRenderer = nullptr;
+    } else {
+        auto font = _gameEngine->getUIManager()->getFont(UIManager::UIFontType::FONT_DEFAULT);
+        _buttonTextRenderer = font->layoutText(_buttonText, &_buttonTextWidth, &_buttonTextHeight);
+    }
 }
 
 void Button::updateSlidyButtonEffect()
@@ -76,12 +85,9 @@ void Button::draw()
     renderer.render(*vb, Ego::PrimitiveType::Quadriliterals, 0, 4);
 
     //Draw centered text in button
-    if(!_buttonText.empty())
+    if(_buttonTextRenderer)
     {
-        int textWidth, textHeight;
-        _gameEngine->getUIManager()->getDefaultFont()->getTextSize(_buttonText, &textWidth, &textHeight);
-
-        _gameEngine->getUIManager()->getDefaultFont()->drawText(_buttonText, getX() + (getWidth()-textWidth)/2, getY() + (getHeight()-textHeight)/2);
+        _buttonTextRenderer->render(getX() + (getWidth() - _buttonTextWidth) / 2, getY() + (getHeight() - _buttonTextHeight) / 2);
     }
 }
 

--- a/game/src/game/GUI/Button.hpp
+++ b/game/src/game/GUI/Button.hpp
@@ -30,13 +30,16 @@ class Button : public GUIComponent
 
     protected:
         bool _mouseOver;
-        std::string _buttonText;
+        std::shared_ptr<Ego::Font::LaidTextRenderer> _buttonTextRenderer;
+        int _buttonTextWidth;
+        int _buttonTextHeight;
 
         static const Ego::Math::Colour4f DEFAULT_BUTTON_COLOUR;
         static const Ego::Math::Colour4f HOVER_BUTTON_COLOUR;
         static const Ego::Math::Colour4f DISABLED_BUTTON_COLOUR;
 
     private:
+        std::string _buttonText;
         std::function<void()> _onClickFunction;
         int _hotkey;
         float _slidyButtonTargetX;

--- a/game/src/game/GUI/CharacterWindow.cpp
+++ b/game/src/game/GUI/CharacterWindow.cpp
@@ -12,7 +12,7 @@ namespace Ego
 namespace GUI
 {
 
-static const int LINE_SPACING_OFFSET = 5; //To make space between lines less
+static const int LINE_SPACING_OFFSET = -2; //To make space between lines less
 
 CharacterWindow::CharacterWindow(const std::shared_ptr<Object> &object) : InternalWindow(object->getName()),
     _character(object),

--- a/game/src/game/GUI/IconButton.cpp
+++ b/game/src/game/GUI/IconButton.cpp
@@ -73,12 +73,9 @@ void IconButton::draw()
  	}
 
     //Draw text on left side in button
-    if(!_buttonText.empty())
+    if(_buttonTextRenderer)
     {
-        int textWidth, textHeight;
-        _gameEngine->getUIManager()->getDefaultFont()->getTextSize(_buttonText, &textWidth, &textHeight);
-
-        _gameEngine->getUIManager()->getDefaultFont()->drawText(_buttonText, getX() + 5, getY() + (getHeight()-textHeight)/2);
+        _buttonTextRenderer->render(getX() + 5, getY() + (getHeight() - _buttonTextHeight) / 2);
     }
 }
 

--- a/game/src/game/GUI/Label.cpp
+++ b/game/src/game/GUI/Label.cpp
@@ -3,6 +3,7 @@
 Label::Label(const std::string &text, const UIManager::UIFontType font) :
     _text(text),
     _font(_gameEngine->getUIManager()->getFont(font)),
+    _textRenderer(),
     _color(Ego::Math::Colour4f::white())
 {
     if(!text.empty()) {
@@ -13,7 +14,8 @@ Label::Label(const std::string &text, const UIManager::UIFontType font) :
 void Label::draw()
 {
     //Draw text
-    _font->drawTextBox(_text, getX(), getY(), getWidth(), getHeight(), _font->getLineSpacing(), _color);
+    if (_textRenderer)
+        _textRenderer->render(getX(), getY(), _color);
 }
 
 void Label::setText(const std::string &text)
@@ -22,7 +24,7 @@ void Label::setText(const std::string &text)
 
 	//Recalculate our size
 	int textWidth, textHeight;
-    _font->getTextBoxSize(_text, 25, &textWidth, &textHeight);
+    _textRenderer = _font->layoutTextBox(_text, 0, 0, _font->getLineSpacing(), &textWidth, &textHeight);
 	setSize(textWidth, textHeight);
 }
 
@@ -32,7 +34,7 @@ void Label::setFont(const std::shared_ptr<Ego::Font> &font)
 
     //Recalculate our size
     int textWidth, textHeight;
-    _font->getTextBoxSize(_text, 25, &textWidth, &textHeight);
+    _textRenderer = _font->layoutTextBox(_text, 0, 0, _font->getLineSpacing(), &textWidth, &textHeight);
     setSize(textWidth, textHeight);
 }
 

--- a/game/src/game/GUI/Label.hpp
+++ b/game/src/game/GUI/Label.hpp
@@ -45,5 +45,6 @@ public:
 private:
     std::string _text;
     std::shared_ptr<Ego::Font> _font;
+    std::shared_ptr<Ego::Font::LaidTextRenderer> _textRenderer;
     Ego::Math::Colour4f _color;
 };

--- a/game/src/game/GUI/LevelUpWindow.cpp
+++ b/game/src/game/GUI/LevelUpWindow.cpp
@@ -153,7 +153,7 @@ LevelUpWindow::LevelUpWindow(const std::shared_ptr<Object> &object) : InternalWi
 
     //Level
     buffer << std::to_string(_character->getExperienceLevel() + 1);
-    switch(_character->getExperienceLevel())
+    switch(_character->getExperienceLevel() + 1)
     {
         case 1:
             buffer << "st";
@@ -523,7 +523,7 @@ void LevelUpWindow::setHoverPerk(Ego::Perks::PerkID id)
     }
 
     _perkIncreaseLabel->setCenterPosition(getX() + getWidth()/2, getY() + _desciptionLabelOffset + 10, true);        
-    _descriptionLabel->setCenterPosition(getX() + getWidth()/2, _perkIncreaseLabel->getY() + _perkIncreaseLabel->getHeight()-10, true);
+    _descriptionLabel->setCenterPosition(getX() + getWidth()/2, _perkIncreaseLabel->getY() + _perkIncreaseLabel->getHeight()-3, true);
 }
 
 Ego::Perks::PerkID LevelUpWindow::getCurrentPerk() const

--- a/game/src/game/GUI/ModuleSelector.cpp
+++ b/game/src/game/GUI/ModuleSelector.cpp
@@ -109,7 +109,7 @@ void ModuleSelector::drawContainer()
 
         // Draw module Name first
         Ego::Renderer::get().setColour(Ego::Colour4f::white());
-        _gameEngine->getUIManager()->getDefaultFont()->drawTextBox(_selectedModule->getName(), getX() + 5, getY() + 5, getWidth() - 10, 20, 25);
+        _gameEngine->getUIManager()->getDefaultFont()->drawTextBox(_selectedModule->getName(), getX() + 5, getY() + 5, getWidth() - 10, 26, 25);
         
 
         // Now difficulty
@@ -117,12 +117,12 @@ void ModuleSelector::drawContainer()
         {
             int textWidth, textHeight;
             _gameEngine->getUIManager()->getDefaultFont()->getTextSize("Difficulty: ", &textWidth, &textHeight);
-            _gameEngine->getUIManager()->getDefaultFont()->drawTextBox("Difficulty: ", getX() + 5, getY() + 25, getWidth() - 10, textHeight, 25);
+            _gameEngine->getUIManager()->getDefaultFont()->drawTextBox("Difficulty: ", getX() + 5, getY() + 30, getWidth() - 10, textHeight, 25);
 
             // Draw one skull per rated difficulty
             for (int i = 0; i < _selectedModule->getRank(); ++i)
             {
-                draw_icon_texture(TextureManager::get().get_valid_ptr(TX_SKULL), getX() + 5 + textWidth + i*textHeight, getY() + 28, 0xFF, 0, textHeight - 4, true);
+                draw_icon_texture(TextureManager::get().get_valid_ptr(TX_SKULL), getX() + 5 + textWidth + i*textHeight, getY() + 33, 0xFF, 0, textHeight - 4, true);
             }
         }
 
@@ -153,7 +153,7 @@ void ModuleSelector::drawContainer()
             buffer << line << '\n';;
         }
 
-        _gameEngine->getUIManager()->getDefaultFont()->drawTextBox(buffer.str(), getX() + 5, getY() + 45, getWidth() - 10, getHeight() - 50, 25);
+        _gameEngine->getUIManager()->getDefaultFont()->drawTextBox(buffer.str(), getX() + 5, getY() + 55, getWidth() - 10, getHeight() - 60, 25);
     }
 }
 

--- a/game/src/game/GameStates/DebugFontRenderingState.cpp
+++ b/game/src/game/GameStates/DebugFontRenderingState.cpp
@@ -1,0 +1,259 @@
+//********************************************************************************************
+//*
+//*    This file is part of Egoboo.
+//*
+//*    Egoboo is free software: you can redistribute it and/or modify it
+//*    under the terms of the GNU General Public License as published by
+//*    the Free Software Foundation, either version 3 of the License, or
+//*    (at your option) any later version.
+//*
+//*    Egoboo is distributed in the hope that it will be useful, but
+//*    WITHOUT ANY WARRANTY; without even the implied warranty of
+//*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//*    General Public License for more details.
+//*
+//*    You should have received a copy of the GNU General Public License
+//*    along with Egoboo.  If not, see <http://www.gnu.org/licenses/>.
+//*
+//********************************************************************************************
+
+/// @file game/GameStates/DebugModuleLoadingState.cpp
+/// @details Debugging state where one can debug font layout and rendering
+/// @author Johan Jansen, penguinflyer5234
+
+#include "game/GameStates/DebugFontRenderingState.hpp"
+#include "game/Core/GameEngine.hpp"
+#include "game/GUI/Button.hpp"
+#include "game/GUI/Label.hpp"
+#include "game/GUI/ScrollableList.hpp"
+
+#include "game/renderer_2d.h"
+
+class DebugFontRenderingState::DebugLabel : public GUIComponent
+{
+public:
+    DebugLabel(const std::string &text) :
+    _text(text),
+    _font(_gameEngine->getUIManager()->getFont(UIManager::FONT_DEFAULT)),
+    _textRenderer(),
+    _maxColor(0, 0, .7, 1),
+    _textColor(0, 1, 0, .4),
+    _maxWidth(0),
+    _maxHeight(0),
+    _textWidth(0),
+    _textHeight(0)
+    {
+        redraw();
+    }
+    
+    void draw() override {
+        ego_frect_t src, tx;
+        
+        src.xmin = getX();
+        src.ymin = getY();
+        src.xmax = src.xmin + _maxWidth;
+        src.ymax = src.ymin + _maxHeight;
+        draw_quad_2d(nullptr, src, tx, true, _maxColor);
+        
+        src.xmax = src.xmin + _textWidth;
+        src.ymax = src.ymin + _textHeight;
+        draw_quad_2d(nullptr, src, tx, true, _textColor);
+        
+        _textRenderer->render(getX(), getY());
+    }
+    
+    void setFont(const std::shared_ptr<Ego::Font> &font) {
+        _font = font;
+        redraw();
+    }
+    
+    void setMaxWidth(int maxWidth) {
+        _maxWidth = maxWidth;
+        redraw();
+    }
+    
+    void setMaxHeight(int maxHeight) {
+        _maxHeight = maxHeight;
+        redraw();
+    }
+    
+private:
+    void redraw() {
+        int textWidth, textHeight;
+        _textRenderer = _font->layoutTextBox(_text, _maxWidth, _maxHeight, 0, &textWidth, &textHeight);
+        _textWidth = textWidth;
+        _textHeight = textHeight;
+        if (_maxWidth > 0)
+            textWidth = _maxWidth;
+        if (_maxHeight > 0)
+            textHeight = _maxHeight;
+        setSize(textWidth, textHeight);
+    }
+    
+    std::string _text;
+    std::shared_ptr<Ego::Font> _font;
+    std::shared_ptr<Ego::Font::LaidTextRenderer> _textRenderer;
+    Ego::Math::Colour4f _maxColor, _textColor;
+    int _maxWidth, _maxHeight;
+    int _textWidth, _textHeight;
+};
+
+DebugFontRenderingState::DebugFontRenderingState()
+{
+    const int SCREEN_WIDTH = _gameEngine->getUIManager()->getScreenWidth();
+    const int SCREEN_HEIGHT = _gameEngine->getUIManager()->getScreenHeight();
+    using UIFontType = UIManager::UIFontType;
+    
+    int x = 125;
+    int width = (SCREEN_WIDTH - 110) / 4 - 20;
+    
+    std::stringstream debugTextStream;
+    std::vector<char> ascii{10};
+    for (char i = 32; i < 127; i++) ascii.emplace_back(i);
+    
+    for (int i = 0; i < 2560; i++)
+        debugTextStream << Random::getRandomElement(ascii);
+    
+    std::string debugText = debugTextStream.str();
+    _textLabel = std::make_shared<DebugLabel>(debugText);
+    _textLabel->setPosition(5, 5);
+    addComponent(_textLabel);
+    
+    auto button = std::make_shared<Button>("Back");
+    button->setOnClickFunction([this] { endState(); } );
+    button->setWidth(100);
+    button->setPosition(5, SCREEN_HEIGHT - button->getHeight() - 5);
+    addComponent(button);
+    
+    button = std::make_shared<Button>("Default");
+    button->setOnClickFunction([this] { setFont(UIFontType::FONT_DEFAULT); });
+    button->setWidth(width);
+    button->setPosition(x, SCREEN_HEIGHT - button->getHeight() - 5);
+    x += width + 20;
+    addComponent(button);
+    
+    button = std::make_shared<Button>("Floating Text");
+    button->setOnClickFunction([this] { setFont(UIFontType::FONT_FLOATING_TEXT); });
+    button->setWidth(width);
+    button->setPosition(x, SCREEN_HEIGHT - button->getHeight() - 5);
+    x += width + 20;
+    addComponent(button);
+    
+    button = std::make_shared<Button>("Debug");
+    button->setOnClickFunction([this] { setFont(UIFontType::FONT_DEBUG); });
+    button->setWidth(width);
+    button->setPosition(x, SCREEN_HEIGHT - button->getHeight() - 5);
+    x += width + 20;
+    addComponent(button);
+    
+    button = std::make_shared<Button>("Game");
+    button->setOnClickFunction([this] { setFont(UIFontType::FONT_GAME); });
+    button->setWidth(width);
+    button->setPosition(x, SCREEN_HEIGHT - button->getHeight() - 5);
+    x += width + 20;
+    addComponent(button);
+    
+    x = 5;
+    _missingSpace = button->getHeight() * 2 + 30;
+    int y = SCREEN_HEIGHT - _missingSpace + 20;
+    
+    _maxWidth = SCREEN_WIDTH - 10;
+    _maxHeight = SCREEN_HEIGHT - _missingSpace;
+    
+    _textLabel->setMaxWidth(_maxWidth);
+    _textLabel->setMaxHeight(_maxHeight);
+    
+    auto label = std::make_shared<Label>("Width");
+    label->setPosition(x, y);
+    addComponent(label);
+    x += label->getWidth() + 15;
+    
+    button = std::make_shared<Button>("<<");
+    button->setPosition(x, y);
+    button->setWidth(35);
+    button->setOnClickFunction([this] { setMaxWidth(0); });
+    addComponent(button);
+    x += 40;
+    
+    button = std::make_shared<Button>("<");
+    button->setPosition(x, y);
+    button->setWidth(35);
+    button->setOnClickFunction([this] { setMaxWidth(_maxWidth - 1); });
+    addComponent(button);
+    x += 40;
+    
+    _widthButton = std::make_shared<Button>(std::to_string(_maxWidth));
+    _widthButton->setPosition(x, y);
+    _widthButton->setWidth(75);
+    addComponent(_widthButton);
+    x += 80;
+    
+    button = std::make_shared<Button>(">");
+    button->setPosition(x, y);
+    button->setWidth(35);
+    button->setOnClickFunction([this] { setMaxWidth(_maxWidth + 1); });
+    addComponent(button);
+    x += 40;
+    
+    button = std::make_shared<Button>(">>");
+    button->setPosition(x, y);
+    button->setWidth(35);
+    button->setOnClickFunction([this] { setMaxWidth(std::numeric_limits<int>::max()); });
+    addComponent(button);
+    x += 55;
+    
+    label = std::make_shared<Label>("Height");
+    label->setPosition(x, y);
+    addComponent(label);
+    x += label->getWidth() + 15;
+    
+    button = std::make_shared<Button>("<<");
+    button->setPosition(x, y);
+    button->setWidth(35);
+    button->setOnClickFunction([this] { setMaxHeight(0); });
+    addComponent(button);
+    x += 40;
+    
+    button = std::make_shared<Button>("<");
+    button->setPosition(x, y);
+    button->setWidth(35);
+    button->setOnClickFunction([this] { setMaxHeight(_maxHeight - 1); });
+    addComponent(button);
+    x += 40;
+    
+    _heightButton = std::make_shared<Button>(std::to_string(_maxHeight));
+    _heightButton->setPosition(x, y);
+    _heightButton->setWidth(75);
+    addComponent(_heightButton);
+    x += 80;
+    
+    button = std::make_shared<Button>(">");
+    button->setPosition(x, y);
+    button->setWidth(35);
+    button->setOnClickFunction([this] { setMaxHeight(_maxHeight + 1); });
+    addComponent(button);
+    x += 40;
+    
+    button = std::make_shared<Button>(">>");
+    button->setPosition(x, y);
+    button->setWidth(35);
+    button->setOnClickFunction([this] { setMaxHeight(std::numeric_limits<int>::max()); });
+    addComponent(button);
+    x += 55;
+}
+
+void DebugFontRenderingState::setFont(UIManager::UIFontType font) {
+    _textLabel->setFont(_gameEngine->getUIManager()->getFont(font));
+}
+
+void DebugFontRenderingState::setMaxHeight(int maxHeight) {
+    _maxHeight = Ego::Math::constrain(maxHeight, 0, _gameEngine->getUIManager()->getScreenHeight() - _missingSpace);
+    _textLabel->setMaxHeight(_maxHeight);
+    _heightButton->setText(std::to_string(_maxHeight));
+}
+
+void DebugFontRenderingState::setMaxWidth(int maxWidth) {
+    _maxWidth = Ego::Math::constrain(maxWidth, 0, _gameEngine->getUIManager()->getScreenWidth() - 10);
+    _textLabel->setMaxWidth(_maxWidth);
+    _widthButton->setText(std::to_string(_maxWidth));
+}

--- a/game/src/game/GameStates/DebugFontRenderingState.hpp
+++ b/game/src/game/GameStates/DebugFontRenderingState.hpp
@@ -1,0 +1,55 @@
+//********************************************************************************************
+//*
+//*    This file is part of Egoboo.
+//*
+//*    Egoboo is free software: you can redistribute it and/or modify it
+//*    under the terms of the GNU General Public License as published by
+//*    the Free Software Foundation, either version 3 of the License, or
+//*    (at your option) any later version.
+//*
+//*    Egoboo is distributed in the hope that it will be useful, but
+//*    WITHOUT ANY WARRANTY; without even the implied warranty of
+//*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//*    General Public License for more details.
+//*
+//*    You should have received a copy of the GNU General Public License
+//*    along with Egoboo.  If not, see <http://www.gnu.org/licenses/>.
+//*
+//********************************************************************************************
+
+/// @file game/gamestates/DebugModuleLoadingState.hpp
+/// @details Debugging state where one can debug font layout and rendering
+/// @author Johan Jansen, penguinflyer5234
+
+#pragma once
+
+#include "game/GameStates/GameState.hpp"
+#include "game/GUI/UIManager.hpp"
+
+class Button;
+
+class DebugFontRenderingState : public GameState
+{
+public:
+	DebugFontRenderingState();
+    
+    void update() override {}
+    
+protected:
+    void drawContainer() override {}
+    
+private:
+    void setFont(UIManager::UIFontType font);
+    void setMaxWidth(int maxWidth);
+    void setMaxHeight(int maxHeight);
+    
+    class DebugLabel;
+    
+    std::shared_ptr<DebugLabel> _textLabel;
+    std::shared_ptr<Button> _widthButton;
+    std::shared_ptr<Button> _heightButton;
+    std::shared_ptr<Button> _newlineButton;
+    
+    int _missingSpace;
+    int _maxWidth, _maxHeight;
+};

--- a/game/src/game/GameStates/DebugMainMenuState.cpp
+++ b/game/src/game/GameStates/DebugMainMenuState.cpp
@@ -1,0 +1,63 @@
+//********************************************************************************************
+//*
+//*    This file is part of Egoboo.
+//*
+//*    Egoboo is free software: you can redistribute it and/or modify it
+//*    under the terms of the GNU General Public License as published by
+//*    the Free Software Foundation, either version 3 of the License, or
+//*    (at your option) any later version.
+//*
+//*    Egoboo is distributed in the hope that it will be useful, but
+//*    WITHOUT ANY WARRANTY; without even the implied warranty of
+//*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//*    General Public License for more details.
+//*
+//*    You should have received a copy of the GNU General Public License
+//*    along with Egoboo.  If not, see <http://www.gnu.org/licenses/>.
+//*
+//********************************************************************************************
+
+/// @file game/GameStates/DebugMainMenuState.cpp
+/// @details State that contains buttons to all non-module related debugging states.
+/// @author Johan Jansen, penguinflyer5234
+
+#include "game/GameStates/DebugMainMenuState.hpp"
+#include "game/Core/GameEngine.hpp"
+#include "game/GUI/Button.hpp"
+
+#include "game/GameStates/DebugFontRenderingState.hpp"
+#include "game/GameStates/DebugModuleLoadingState.hpp"
+#include "game/GameStates/DebugObjectLoadingState.hpp"
+
+DebugMainMenuState::DebugMainMenuState() {
+    const int SCREEN_HEIGHT = _gameEngine->getUIManager()->getScreenHeight();
+    
+    auto button = std::make_shared<Button>("Back");
+    button->setPosition(5, SCREEN_HEIGHT - button->getHeight() - 5);
+    button->setWidth(150);
+    button->setOnClickFunction([this] { endState(); });
+    addComponent(button);
+    
+    int y = 5;
+    
+    button = std::make_shared<Button>("Load Modules");
+    button->setPosition(5, y);
+    button->setWidth(300);
+    button->setOnClickFunction([] { _gameEngine->pushGameState(std::make_shared<DebugModuleLoadingState>()); });
+    addComponent(button);
+    y += button->getHeight() + 10;
+    
+    button = std::make_shared<Button>("Load Objects");
+    button->setPosition(5, y);
+    button->setWidth(300);
+    button->setOnClickFunction([] { _gameEngine->pushGameState(std::make_shared<DebugObjectLoadingState>()); });
+    addComponent(button);
+    y += button->getHeight() + 10;
+    
+    button = std::make_shared<Button>("Font Rendering");
+    button->setPosition(5, y);
+    button->setWidth(300);
+    button->setOnClickFunction([] { _gameEngine->pushGameState(std::make_shared<DebugFontRenderingState>()); });
+    addComponent(button);
+    y += button->getHeight() + 10;
+}

--- a/game/src/game/GameStates/DebugMainMenuState.hpp
+++ b/game/src/game/GameStates/DebugMainMenuState.hpp
@@ -1,0 +1,37 @@
+//********************************************************************************************
+//*
+//*    This file is part of Egoboo.
+//*
+//*    Egoboo is free software: you can redistribute it and/or modify it
+//*    under the terms of the GNU General Public License as published by
+//*    the Free Software Foundation, either version 3 of the License, or
+//*    (at your option) any later version.
+//*
+//*    Egoboo is distributed in the hope that it will be useful, but
+//*    WITHOUT ANY WARRANTY; without even the implied warranty of
+//*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//*    General Public License for more details.
+//*
+//*    You should have received a copy of the GNU General Public License
+//*    along with Egoboo.  If not, see <http://www.gnu.org/licenses/>.
+//*
+//********************************************************************************************
+
+/// @file game/GameStates/DebugMainMenuState.hpp
+/// @details State that contains buttons to all non-module related debugging states.
+/// @author Johan Jansen, penguinflyer5234
+
+#pragma once
+
+#include "game/GameStates/GameState.hpp"
+
+class DebugMainMenuState : public GameState
+{
+public:
+	DebugMainMenuState();
+    
+    void update() override {}
+    
+protected:
+    void drawContainer() override {}
+};

--- a/game/src/game/GameStates/DebugObjectLoadingState.cpp
+++ b/game/src/game/GameStates/DebugObjectLoadingState.cpp
@@ -1,0 +1,387 @@
+//********************************************************************************************
+//*
+//*    This file is part of Egoboo.
+//*
+//*    Egoboo is free software: you can redistribute it and/or modify it
+//*    under the terms of the GNU General Public License as published by
+//*    the Free Software Foundation, either version 3 of the License, or
+//*    (at your option) any later version.
+//*
+//*    Egoboo is distributed in the hope that it will be useful, but
+//*    WITHOUT ANY WARRANTY; without even the implied warranty of
+//*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//*    General Public License for more details.
+//*
+//*    You should have received a copy of the GNU General Public License
+//*    along with Egoboo.  If not, see <http://www.gnu.org/licenses/>.
+//*
+//********************************************************************************************
+
+/// @file game/GameStates/DebugObjectLoadingState.cpp
+/// @details Debugging state where one can debug loading objects
+///          from the global repository or individual modules.
+/// @author Johan Jansen, penguinflyer5234
+
+#include "game/GameStates/DebugObjectLoadingState.hpp"
+#include "game/GameStates/PlayingState.hpp"
+#include "game/GameStates/LoadPlayerElement.hpp"
+#include "game/Core/GameEngine.hpp"
+#include "egolib/egoboo_setup.h"
+#include "game/graphic.h"
+#include "game/GUI/Button.hpp"
+#include "game/GUI/Label.hpp"
+#include "game/GUI/Image.hpp"
+#include "game/GUI/ScrollableList.hpp"
+#include "egolib/Math/Random.hpp"
+#include "egolib/Audio/AudioSystem.hpp"
+
+//For loading stuff
+#include "game/Graphics/CameraSystem.hpp"
+#include "game/game.h"
+#include "game/graphic_billboard.h"
+#include "game/link.h"
+#include "game/collision.h"
+#include "game/renderer_2d.h"
+#include "game/bsp.h"
+#include "egolib/fileutil.h"
+
+class DebugObjectLoadingState::GrowableLabel : public GUIComponent
+{
+public:
+    GrowableLabel(const std::string &text) :
+    _text(text),
+    _font(_gameEngine->getUIManager()->getFont(UIManager::FONT_DEBUG)),
+    _textRenderer()
+    {
+        redraw();
+    }
+    
+    void draw() override {
+        _textRenderer->render(getX(), getY());
+    }
+    
+    void setText(const std::string &text) {
+        _text = text;
+        redraw();
+    }
+    
+    void setWidth(const int width) override {
+        GUIComponent::setWidth(width);
+        redraw();
+    }
+    
+    void doParentRelayout();
+    
+private:
+    void redraw() {
+        int textHeight;
+        _textRenderer = _font->layoutTextBox(_text, getWidth(), 0, 0, nullptr, &textHeight);
+        setHeight(textHeight);
+        doParentRelayout();
+    }
+    
+    std::string _text;
+    std::shared_ptr<Ego::Font> _font;
+    std::shared_ptr<Ego::Font::LaidTextRenderer> _textRenderer;
+};
+
+struct DebugObjectLoadingState::ObjectGUIContainer : public ComponentContainer, public GUIComponent
+{
+    ObjectGUIContainer(const std::string &objectName,
+                       const std::weak_ptr<ModuleLoader> &module) :
+    _objectPath("/mp_objects/" + objectName),
+    _objectName(std::make_shared<Button>(objectName)),
+    _loadingText(std::make_shared<DebugObjectLoadingState::GrowableLabel>("Not Loaded")),
+    _module(module)
+    {
+        _objectName->setSize(250, 30);
+        
+        addComponent(_objectName);
+        addComponent(_loadingText);
+        
+        const int SCREEN_WIDTH = _gameEngine->getUIManager()->getScreenWidth();
+        setSize(SCREEN_WIDTH - 50, 30);
+        _loadingText->setWidth(SCREEN_WIDTH - 50 - 265);
+        relayout();
+    }
+    
+    void setOnClick(const std::function<void()> &onClick)
+    {
+        _objectName->setOnClickFunction(onClick);
+    }
+    
+    void draw() override
+    {
+        drawAll();
+    }
+    
+    void drawContainer() override {}
+    
+    void setPosition(const int x, const int y) override
+    {
+        GUIComponent::setPosition(x, y);
+        _objectName->setPosition(x, y);
+        _loadingText->setPosition(x + 265, y + (getHeight() - _loadingText->getHeight()) / 2);
+    }
+    
+    bool notifyMouseClicked(const int button, const int x, const int y) override
+    {
+        return ComponentContainer::notifyMouseClicked(button, x, y);
+    }
+    
+    bool notifyMouseMoved(const int x, const int y) override
+    {
+        return ComponentContainer::notifyMouseMoved(x, y);
+    }
+    
+    void relayout() {
+        int height = std::max(_objectName->getHeight(), _loadingText->getHeight());
+        setHeight(height);
+        _loadingText->setY(getY() + (height - _loadingText->getHeight()) / 2);
+        auto scrollList = dynamic_cast<ScrollableList *>(getParent());
+        if (!scrollList) return;
+        scrollList->forceUpdate();
+    }
+    
+    std::string _objectPath;
+    std::shared_ptr<Button> _objectName;
+    std::shared_ptr<DebugObjectLoadingState::GrowableLabel> _loadingText;
+    std::weak_ptr<ModuleLoader> _module;
+};
+
+void DebugObjectLoadingState::GrowableLabel::doParentRelayout() {
+    auto myGUIContainer = dynamic_cast<ObjectGUIContainer *>(getParent());
+    if (!myGUIContainer) return;
+    myGUIContainer->relayout();
+}
+
+
+struct DebugObjectLoadingState::ModuleLoader : public std::enable_shared_from_this<ModuleLoader> {
+    ModuleLoader(const std::string &moduleName) :
+    ModuleLoader(moduleName, "/modules/" + moduleName + "/objects")
+    {}
+    
+protected:
+    ModuleLoader(const std::string &moduleName, const std::string &objectLocationPath) :
+    _moduleName(moduleName),
+    _objectLocationPath(objectLocationPath)
+    {}
+    
+public:
+    void loadObjectList() {
+        auto self = shared_from_this();
+        setupPaths();
+        vfs_search_context_t *context = vfs_findFirst(_objectLocationPath.c_str(), "obj", VFS_SEARCH_DIR | VFS_SEARCH_BARE);
+        while (context) {
+            std::string objName = vfs_search_context_get_current(context);
+            _objects.emplace_back(new ObjectGUIContainer(objName, self));
+            vfs_findNext(&context);
+        }
+        vfs_findClose(&context);
+    }
+    
+    void setupPaths() {
+        setup_init_module_vfs_paths(_moduleName.c_str());
+    }
+    
+    std::vector<std::shared_ptr<ObjectGUIContainer>> getObjectList() {
+        return _objects;
+    }
+    
+    virtual std::string getModuleName() {
+        return _moduleName;
+    }
+    
+private:
+    std::string _moduleName;
+    std::string _objectLocationPath;
+    std::vector<std::shared_ptr<ObjectGUIContainer>> _objects;
+};
+
+struct DebugObjectLoadingState::GlobalLoader : public ModuleLoader {
+    GlobalLoader() :
+    ModuleLoader("---invalid---", "/mp_objects")
+    {}
+    
+    std::string getModuleName() override {
+        return "~ GLOBAL ~";
+    }
+};
+
+DebugObjectLoadingState::DebugObjectLoadingState() :
+#ifdef _MSC_VER
+_finishedLoading({0}),
+#else
+_finishedLoading(false),
+#endif
+_loadingThread(),
+_scrollableList(),
+_moduleList(),
+_toLoad(),
+_currentLoader()
+{
+    const int SCREEN_WIDTH = _gameEngine->getUIManager()->getScreenWidth();
+    const int SCREEN_HEIGHT = _gameEngine->getUIManager()->getScreenHeight();
+    
+    _scrollableList = std::make_shared<ScrollableList>();
+    _scrollableList->setPosition(8, 8);
+    _scrollableList->setSize(SCREEN_WIDTH - 16, SCREEN_HEIGHT - 56);
+    
+    _moduleList.emplace_back(new GlobalLoader());
+    
+    vfs_search_context_t *context = vfs_findFirst("/modules", "mod", VFS_SEARCH_DIR | VFS_SEARCH_BARE);
+    
+    while (context)
+    {
+        std::string moduleName = vfs_search_context_get_current(context);
+        auto module = std::make_shared<ModuleLoader>(moduleName);
+        _moduleList.emplace_back(module);
+        vfs_findNext(&context);
+    }
+    vfs_findClose(&context);
+    
+    for (const auto &loader : _moduleList) {
+        auto button = std::make_shared<Button>(loader->getModuleName());
+        std::weak_ptr<ModuleLoader> loaderPtr = loader;
+        button->setWidth(SCREEN_WIDTH - 72);
+        button->setOnClickFunction([this, loaderPtr] { addToQueue(loaderPtr.lock()); });
+        _scrollableList->addComponent(button);
+        
+        _currentLoader = loader;
+        loader->loadObjectList();
+        
+        for (const auto &object : loader->getObjectList()) {
+            std::weak_ptr<ObjectGUIContainer> objectPtr = object;
+            object->setOnClick([this, objectPtr] { addToQueue(objectPtr.lock()); });
+            _scrollableList->addComponent(object);
+        }
+    }
+    _scrollableList->forceUpdate();
+    addComponent(_scrollableList);
+    
+    std::shared_ptr<Button> back = std::make_shared<Button>("Back");
+    back->setPosition(8, SCREEN_HEIGHT - 30 - 8);
+    back->setSize(150, 30);
+    back->setOnClickFunction([this] { endState(); });
+    addComponent(back);
+    
+    std::shared_ptr<Button> loadAll = std::make_shared<Button>("Load All");
+    loadAll->setPosition(SCREEN_WIDTH - 150 - 8, SCREEN_HEIGHT - 30 - 8);
+    loadAll->setSize(150, 30);
+    loadAll->setOnClickFunction([this] { for (const auto &a : _moduleList) addToQueue(a); });
+    addComponent(loadAll);
+}
+
+DebugObjectLoadingState::~DebugObjectLoadingState()
+{
+    //Wait until thread is dead
+    if(_loadingThread.joinable()) {
+        _loadingThread.join();
+    }
+}
+
+void DebugObjectLoadingState::addToQueue(const std::shared_ptr<ModuleLoader> &toAdd)
+{
+    if (!toAdd) return;
+    for (const auto &obj : toAdd->getObjectList()) {
+        addToQueue(obj);
+    }
+}
+
+void DebugObjectLoadingState::addToQueue(const std::shared_ptr<ObjectGUIContainer> &toAdd) {
+    if (!toAdd) return;
+    if (std::find(_toLoad.begin(), _toLoad.end(), toAdd) != _toLoad.end()) return;
+    _toLoad.emplace_back(toAdd);
+    toAdd->_loadingText->setText("Waiting...");
+}
+
+//TODO: HACK (no multithreading yet)
+void DebugObjectLoadingState::singleThreadRedrawHack(const std::string &loadingText)
+{
+    // clear the screen
+    gfx_request_clear_screen();
+    gfx_do_clear_screen();
+    
+    _toLoad.front()->_loadingText->setText(loadingText);
+    
+    drawAll();
+    
+    // flip the graphics page
+    gfx_request_flip_pages();
+    gfx_do_flip_pages();
+    SDL_PumpEvents();
+}
+//TODO: HACK END
+
+
+void DebugObjectLoadingState::update()
+{
+    if (!_toLoad.empty()) loadObjectData();
+}
+
+void DebugObjectLoadingState::drawContainer()
+{
+    
+}
+
+void DebugObjectLoadingState::beginState()
+{
+    //Start the background loading thread
+    //_loadingThread = std::thread(&LoadingState2::loadModuleData, this);
+    AudioSystem::get().playMusic(27); //TODO: needs to be referenced by string
+}
+
+void DebugObjectLoadingState::loadObjectData()
+{
+    auto objectModule = _toLoad.front()->_module.lock();
+    if (objectModule != _currentLoader) {
+        _currentLoader = objectModule;
+        _currentLoader->setupPaths();
+    }
+    
+    std::string objectPath = _toLoad.front()->_objectPath;
+    try
+    {
+        singleThreadRedrawHack("Loading...");
+        
+        PRO_REF ref = ProfileSystem::get().loadOneProfile(objectPath, 0);
+        bool isValid = ProfileSystem::get().isValidProfileID(ref);
+        ProfileSystem::get().reset();
+        if (!isValid)
+            throw std::string("Invalid profile ref returned, check log");
+        
+        //Complete!
+        singleThreadRedrawHack("Finished!");
+    }
+    catch (Ego::Core::Exception &ex)
+    {
+        std::string out = std::string("Ego::Exception: ") + std::string(ex);
+        singleThreadRedrawHack(out);
+        log_warning("error loading %s... %s\n", objectPath.c_str(), out.c_str());
+    }
+    catch (std::exception &ex)
+    {
+        std::string out = std::string("std::exception: ") + ex.what();
+        singleThreadRedrawHack(out);
+        log_warning("error loading %s... %s\n", objectPath.c_str(), out.c_str());
+    }
+    catch (std::string &ex)
+    {
+        std::string out = std::string("std::string: ") + ex;
+        singleThreadRedrawHack(out);
+        log_warning("error loading %s... %s\n", objectPath.c_str(), out.c_str());
+    }
+    catch (char *ex)
+    {
+        std::string out = std::string("C string: ") + ex;
+        singleThreadRedrawHack(out);
+        log_warning("error loading %s... %s\n", objectPath.c_str(), out.c_str());
+    }
+    catch (...)
+    {
+        std::string out = "unknown error";
+        singleThreadRedrawHack(out);
+        log_warning("error loading %s... %s\n", objectPath.c_str(), out.c_str());
+    }
+    _toLoad.pop_front();
+}

--- a/game/src/game/GameStates/DebugObjectLoadingState.hpp
+++ b/game/src/game/GameStates/DebugObjectLoadingState.hpp
@@ -1,0 +1,69 @@
+//********************************************************************************************
+//*
+//*    This file is part of Egoboo.
+//*
+//*    Egoboo is free software: you can redistribute it and/or modify it
+//*    under the terms of the GNU General Public License as published by
+//*    the Free Software Foundation, either version 3 of the License, or
+//*    (at your option) any later version.
+//*
+//*    Egoboo is distributed in the hope that it will be useful, but
+//*    WITHOUT ANY WARRANTY; without even the implied warranty of
+//*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//*    General Public License for more details.
+//*
+//*    You should have received a copy of the GNU General Public License
+//*    along with Egoboo.  If not, see <http://www.gnu.org/licenses/>.
+//*
+//********************************************************************************************
+
+/// @file game/GameStates/DebugObjectLoadingState.cpp
+/// @details Debugging state where one can debug loading objects
+///          from the global repository or individual modules.
+/// @author Johan Jansen, penguinflyer5234
+
+#pragma once
+
+#include "game/GameStates/GameState.hpp"
+
+//Forward declarations
+class ModuleProfile;
+class Label;
+class ScrollableList;
+
+class DebugObjectLoadingState : public GameState
+{
+public:
+    DebugObjectLoadingState();
+    ~DebugObjectLoadingState();
+    
+    void update() override;
+    
+    void beginState() override;
+    
+protected:
+    void drawContainer() override;
+    
+    void loadObjectData();
+    
+    /**
+     * ZF> This function is a place-holder hack until we get proper threaded loading working
+     **/
+    void singleThreadRedrawHack(const std::string &loadingText);
+    
+private:
+    std::atomic_bool _finishedLoading;
+    std::thread _loadingThread;
+    std::shared_ptr<ScrollableList> _scrollableList;
+    
+    struct ObjectGUIContainer;
+    struct ModuleLoader;
+    struct GlobalLoader;
+    struct GrowableLabel;
+    std::vector<std::shared_ptr<ModuleLoader>> _moduleList;
+    std::deque<std::shared_ptr<ObjectGUIContainer>> _toLoad;
+    std::shared_ptr<ModuleLoader> _currentLoader;
+    
+    void addToQueue(const std::shared_ptr<ModuleLoader> &toAdd);
+    void addToQueue(const std::shared_ptr<ObjectGUIContainer> &toAdd);
+};

--- a/game/src/game/GameStates/MainMenuState.cpp
+++ b/game/src/game/GameStates/MainMenuState.cpp
@@ -22,7 +22,7 @@
 /// @author Johan Jansen
 
 #include "game/GameStates/MainMenuState.hpp"
-#include "game/GameStates/DebugModuleLoadingState.hpp"
+#include "game/GameStates/DebugMainMenuState.hpp"
 #include "game/GameStates/SelectModuleState.hpp"
 #include "game/GameStates/SelectPlayersState.hpp"
 #include "game/GameStates/OptionsScreen.hpp"
@@ -129,7 +129,7 @@ MainMenuState::MainMenuState() :
         debugButton->setSize(200, 30);
         debugButton->setOnClickFunction(
         []{
-            _gameEngine->pushGameState(std::make_shared<DebugModuleLoadingState>());
+            _gameEngine->pushGameState(std::make_shared<DebugMainMenuState>());
         });
         addComponent(debugButton);
         _slidyButtons.push_front(debugButton);


### PR DESCRIPTION
Rewrite how TrueType fonts are handled; the code now uses atlases and vertex buffers instead of a texture for each string of text.

TODO:
- Finish adding support for the new `layoutText` API in GUI
- Relayout text as needed
- Remove caches for `sizeText` and `drawText`

TODO, eventually:
- Move the UTF-8 to codepoints code and expand it to support all UTF-8-encodable codepoints (SDL_ttf only supports 16-bit codepoints)
- Split the Font class into a base Font class and TTFont and BitmapFont subclasses